### PR TITLE
Skip the bell sound if the timer passed a while ago

### DIFF
--- a/Little Moments/ScheduledBellAlert.swift
+++ b/Little Moments/ScheduledBellAlert.swift
@@ -1,10 +1,3 @@
-//
-//  ScheduledBellAlert.swift
-//  Just Now
-//
-//  Created by Illya Bomash on 5/27/23.
-//
-
 import Foundation
 
 protocol ScheduledAlert: Equatable {
@@ -52,12 +45,17 @@ class OneTimeScheduledBellAlert: ScheduledAlert {
       return
     }
     if self.isDone(secondsElapsed: secondsElapsed) {
-      self.doTrigger()
+      self.doTrigger(secondsElapsed: secondsElapsed)
       hasTriggered = true
     }
   }
 
-  func doTrigger() {
+  func doTrigger(secondsElapsed: CGFloat) {
+    let MAX_DELAY: CGFloat = 15.0
+    if secondsElapsed - targetTimeInSec > MAX_DELAY {
+      print("Skipping sound due to delay")
+      return
+    }
     print("Triggered \(name) alert")
     SoundManager.playSound()
   }

--- a/Little Moments/ScheduledBellAlert.swift
+++ b/Little Moments/ScheduledBellAlert.swift
@@ -51,7 +51,7 @@ class OneTimeScheduledBellAlert: ScheduledAlert {
   }
 
   func doTrigger(secondsElapsed: CGFloat) {
-    let MAX_DELAY: CGFloat = 15.0
+    let MAX_DELAY: CGFloat = 5.0
     if secondsElapsed - targetTimeInSec > MAX_DELAY {
       print("Skipping sound due to delay")
       return


### PR DESCRIPTION
Add logic to skip playing the bell sound if delayed more than 15 seconds past the end of the timer.

* Add a constant global variable `MAX_DELAY` with a value of 15 seconds.
* Add a parameter `secondsElapsed` to the `doTrigger()` method to pass the elapsed time.
* Add a check in the `doTrigger()` method to determine if the delay is more than `MAX_DELAY` seconds past the end of the timer.
* Skip calling `SoundManager.playSound()` if the delay is more than `MAX_DELAY` seconds in the `doTrigger()` method.
* Update the call to `doTrigger()` in the `checkTrigger()` method to pass the `secondsElapsed` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ibomash/LittleMoments/pull/1?shareId=2d1780f9-1890-4f4a-be22-faf9a4fed7f2).