### PR TITLE
Turn TimerStartView's showSettingsView into a shared state in AppState

### DIFF
--- a/Little Moments/AppState.swift
+++ b/Little Moments/AppState.swift
@@ -1,13 +1,7 @@
-//
-//  AppState.swift
-//  Little Moments
-//
-//  Created by Illya Bomash on 1/16/25.
-//
-
 import SwiftUI
 
 class AppState: ObservableObject {
   static let shared = AppState()
   @Published var showTimerRunningView: Bool = false
+  @Published var showSettingsView: Bool = false
 }

--- a/Little Moments/TimerStartView.swift
+++ b/Little Moments/TimerStartView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct TimerStartView: View {
   @StateObject private var appState = AppState.shared
-  @State private var showSettingsView: Bool = false
 
   var body: some View {
     NavigationStack {
@@ -24,7 +23,7 @@ struct TimerStartView: View {
 
         HStack {
           Button(action: {
-            showSettingsView = true
+            appState.showSettingsView = true
           }) {
             Image(systemName: "gear")
               .resizable()
@@ -58,7 +57,7 @@ struct TimerStartView: View {
     .sheet(isPresented: $appState.showTimerRunningView) {
       TimerRunningView()
     }
-    .sheet(isPresented: $showSettingsView) {
+    .sheet(isPresented: $appState.showSettingsView) {
       SettingsView()
     }
   }


### PR DESCRIPTION
Add shared state `showSettingsView` to `AppState` and update `TimerStartView` to use it.

* Add `@Published var showSettingsView: Bool = false` to `AppState` class in `Little Moments/AppState.swift`.
* Remove local state variable `showSettingsView` from `TimerStartView` in `Little Moments/TimerStartView.swift`.
* Update `TimerStartView` to use `appState.showSettingsView` instead of the local state variable to present `SettingsView`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ibomash/LittleMoments/pull/3?shareId=be0324b0-1897-4fa9-b340-a1970c96f57f).