### PR TITLE
Fix TimerTests setup order

### DIFF
--- a/LittleMoments/Tests/UnitTests/TimerTests/TimerTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/TimerTests.swift
@@ -20,8 +20,8 @@ final class TimerTests: XCTestCase {
   /// Creates a fresh TimerViewModel instance to ensure tests start with a clean state
   override func setUp() {
     super.setUp()
-    timerViewModel = TimerViewModel()
     UserDefaultsReset.resetDefaults()
+    timerViewModel = TimerViewModel()
   }
 
   /// Tear down method runs after each test


### PR DESCRIPTION
## Summary
- ensure UserDefaults are reset prior to creating TimerViewModel in tests

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec fastlane test_unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8caad40c8328aaa84c8594a5c6b9