### PR TITLE
Add Control Center control to start meditation

### DIFF
--- a/LittleMoments/WidgetExtension/MeditationControl.swift
+++ b/LittleMoments/WidgetExtension/MeditationControl.swift
@@ -1,0 +1,16 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+import ControlCenter
+
+@available(iOS 18.0, *)
+struct MeditationControl: ControlWidget {
+  var body: some ControlWidgetConfiguration {
+    ControlWidgetConfiguration(kind: "MeditationControl") {
+      Control("Start Meditation", systemImage: "brain.head.profile") {
+        try await MeditationSessionIntent().perform()
+      }
+    }
+  }
+}
+

--- a/LittleMoments/WidgetExtension/WidgetBundle.swift
+++ b/LittleMoments/WidgetExtension/WidgetBundle.swift
@@ -7,6 +7,9 @@ struct MeditationWidgets: WidgetBundle {
   @WidgetBundleBuilder
   var body: some Widget {
     MeditationLiveActivityWidget()
+    if #available(iOS 18.0, *) {
+      MeditationControl()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add Control Center widget to trigger a meditation session
- include the new control in widget bundle when available

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c09758cce88328a0f4ef506a25a494