### PR TITLE
Add bootstrap and test scripts with CI bundle caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+      - uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gems-
+      - name: Bootstrap
+        run: scripts/bootstrap.sh
+      - name: Run tests
+        run: scripts/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ Derived/
 # Other files to ignore
 .git.bak/ 
 repomix-output.xml
+
+# Bundler
+vendor/bundle/

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install bundler
+gem install bundler
+
+# Configure bundle path
+bundle config set --local path vendor/bundle
+
+# Install gems
+bundle install --jobs 4 --retry 3
+
+# Install Tuist
+curl -Ls https://install.tuist.io | bash
+
+# Install SwiftLint and swift-format
+if command -v brew >/dev/null 2>&1; then
+  brew install swiftlint swift-format
+else
+  echo "Homebrew not found; skipping SwiftLint and swift-format installation"
+fi
+
+# Generate Xcode project and prefetch Swift packages if possible
+if command -v fastlane >/dev/null 2>&1; then
+  bundle exec fastlane generate || echo "fastlane generate failed; continuing"
+fi
+
+# Optionally resolve package dependencies if xcodebuild is available
+if command -v xcodebuild >/dev/null 2>&1; then
+  xcodebuild -resolvePackageDependencies || true
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle exec fastlane test


### PR DESCRIPTION
## Summary
- Add bootstrap script to install gems, Tuist, SwiftLint, and prefetch packages
- Add test wrapper script for running fastlane tests
- Set up CI workflow with vendor/bundle caching and new scripts
- Ignore vendor/bundle in git

## Testing
- `./scripts/bootstrap.sh` *(fails: 403 "Forbidden")*
- `./scripts/test.sh` *(fails: bundler: command not found: fastlane)*

------
https://chatgpt.com/codex/tasks/task_e_68c09c827718832883a31bc8ef3a689b