### PR TITLE
chore: update year references to 2025

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Illya Bomash, All rights reserved.
+Copyright (c) 2023-2025 Illya Bomash, All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LittleMoments/Features/Settings/Views/SettingsView.swift
+++ b/LittleMoments/Features/Settings/Views/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
         }
 
         Section(header: Text("About")) {
-          Text("Coded by Illya Bomash in 2023.")
+          Text("Coded by Illya Bomash, 2023–2025.")
           if let url = URL(string: "https://github.com/ibomash/LittleMoments") {
             Link(destination: url) {
               Text("Code available on GitHub.")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Little Moments app
 
-Copyright © 2023-2024 Illya Bomash, licensed under a BSD-3 license.
+Copyright © 2023-2025 Illya Bomash, licensed under a BSD-3 license.
 
 ## Why?
 


### PR DESCRIPTION
## Summary
- update README and license to include 2025
- refresh Settings about text for 2025

## Testing
- `fastlane format_code` *(fails: command not found)*
- `fastlane lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1de6a36248328a13c29ab6ab5bc8f