### PR TITLE
feat(intent): support preset duration

### DIFF
--- a/LittleMoments/Features/Meditation/Models/MeditationSessionIntent.swift
+++ b/LittleMoments/Features/Meditation/Models/MeditationSessionIntent.swift
@@ -4,8 +4,18 @@ import SwiftUI
 struct MeditationSessionIntent: AppIntent {
   static var title: LocalizedStringResource { "Start Meditation Session" }
 
+  @Parameter(title: "Duration", description: "Optional duration in seconds")
+  var durationSeconds: Int?
+
+  static var parameterSummary: some ParameterSummary {
+    Summary("Start a session for \(\.$durationSeconds)")
+  }
+
   @MainActor
   func perform() async throws -> some IntentResult {
+    if let durationSeconds {
+      AppState.shared.pendingStartDurationSeconds = durationSeconds
+    }
     AppState.shared.showTimerRunningView = true
     return .result()
   }

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -38,7 +38,9 @@ struct TimerStartView: View {
           ImageButton(
             imageName: "play.fill", buttonText: "Start session",
             action: {
-              let intent = MeditationSessionIntent()
+              let intent = MeditationSessionIntent(
+                durationSeconds: appState.pendingStartDurationSeconds
+              )
               // Print the intent I'm donating
               let donationManager = IntentDonationManager.shared
               // Donate the intent and print confirmation for debugging purposes depending on success or failure

--- a/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
+++ b/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
@@ -53,6 +53,19 @@ final class DeepLinkTests: XCTestCase {
     XCTAssertTrue(AppState.shared.showTimerRunningView)
   }
 
+  func testMeditationSessionIntentPerformWithDurationSetsPreset() {
+    AppState.shared.resetState()
+    let intent = MeditationSessionIntent(durationSeconds: 90)
+    let exp = expectation(description: "intent perform")
+    Task {
+      _ = try? await intent.perform()
+      exp.fulfill()
+    }
+    wait(for: [exp], timeout: 2.0)
+    XCTAssertTrue(AppState.shared.showTimerRunningView)
+    XCTAssertEqual(AppState.shared.pendingStartDurationSeconds, 90)
+  }
+
   func testParseDurationHelper() throws {
     XCTAssertEqual(LittleMomentsApp.parseDurationToSeconds("60"), 60)
     XCTAssertEqual(LittleMomentsApp.parseDurationToSeconds("60s"), 60)


### PR DESCRIPTION
## Summary
- add optional duration parameter to meditation session app intent
- donate duration with start view intents
- cover intent duration with a unit test

## Testing
- `fastlane format_code` *(fails: command not found)*
- `fastlane lint` *(fails: command not found)*
- `fastlane test_unit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c2e4b0584c8328b7a7f265592f5ae9