### PR TITLE
feat(intent): support preset duration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,48 +1,29 @@
+# .swiftlint.yml
 excluded:
+  - Carthage
   - Pods
-  - Little Moments.xcodeproj
-  - Little MomentsTests
-  - Little MomentsUITests
-  - fastlane
+  - DerivedData
 
+# Let swift-format own layout
 disabled_rules:
+  - opening_brace
+  - closing_brace
+  - colon
+  - comma
   - trailing_whitespace
-  - line_length
-  - identifier_name
+  - vertical_whitespace_between_cases
 
+# Keep these, but align with formatter settings
+line_length:
+  warning: 100
+  error: 120
+  ignores_urls: true
+  ignores_comments: true
+  ignores_interpolated_strings: true
+
+vertical_whitespace:
+  max_empty_lines: 1
+
+# If you want import checks, keep this ON (matches OrderedImports)
 opt_in_rules:
-  - empty_count
-  - empty_string
-  - fatal_error_message
-  - force_unwrapping
-  - implicitly_unwrapped_optional
-  - private_outlet
-  - prohibited_super_call
-  - redundant_nil_coalescing
   - sorted_imports
-
-analyzer_rules:
-  - unused_declaration
-  - unused_import
-
-force_cast: warning
-force_try: warning
-force_unwrapping: warning
-
-cyclomatic_complexity:
-  warning: 15
-  error: 25
-
-type_body_length:
-  warning: 300
-  error: 500
-
-file_length:
-  warning: 500
-  error: 1000
-
-function_body_length:
-  warning: 50
-  error: 100
-
-reporter: "xcode" 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+	"servers": {
+		"sosumi.ai": {
+			"url": "https://sosumi.ai/mcp",
+			"type": "http"
+		}
+	},
+	"inputs": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ This project uses Tuist for project generation and Fastlane for build automation
 - UI tests: `LittleMomentsUITests` target
 - Test coverage is enabled for the main app target
 
+### Resources
+
+- Use the `apple_docs_sosumi` tool for Apple developer docs in readable Markdown format. It mirrors everything that would be at developer.apple.com
+
 ## Architecture
 
 ### Core Structure

--- a/LittleMoments/App/iOS/Little_MomentsApp.swift
+++ b/LittleMoments/App/iOS/Little_MomentsApp.swift
@@ -91,7 +91,8 @@ struct LittleMomentsApp: App {
         // First try to get an active timer view model to prepare the session
         // This ensures we capture the startDate before we close the view
         if let activeTimerVC = getActiveTimerViewController(),
-          let timerRunningView = findTimerRunningView(in: activeTimerVC) {
+          let timerRunningView = findTimerRunningView(in: activeTimerVC)
+        {
           // Access the timer view model directly
           timerRunningView.timerViewModel.prepareSessionForFinish()
 
@@ -153,7 +154,8 @@ struct LittleMomentsApp: App {
       print("📲 Processing startSession deep link")
       // Parse optional duration query item (seconds). Accept forms like "60", "60s", "1m".
       if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
-        let items = comps.queryItems {
+        let items = comps.queryItems
+      {
         if let durationString = items.first(where: { $0.name.lowercased() == "duration" })?.value {
           let seconds = Self.parseDurationToSeconds(durationString)
           if let seconds {

--- a/LittleMoments/App/iOS/Little_MomentsApp.swift
+++ b/LittleMoments/App/iOS/Little_MomentsApp.swift
@@ -91,8 +91,7 @@ struct LittleMomentsApp: App {
         // First try to get an active timer view model to prepare the session
         // This ensures we capture the startDate before we close the view
         if let activeTimerVC = getActiveTimerViewController(),
-          let timerRunningView = findTimerRunningView(in: activeTimerVC)
-        {
+          let timerRunningView = findTimerRunningView(in: activeTimerVC) {
           // Access the timer view model directly
           timerRunningView.timerViewModel.prepareSessionForFinish()
 
@@ -154,8 +153,7 @@ struct LittleMomentsApp: App {
       print("📲 Processing startSession deep link")
       // Parse optional duration query item (seconds). Accept forms like "60", "60s", "1m".
       if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
-        let items = comps.queryItems
-      {
+        let items = comps.queryItems {
         if let durationString = items.first(where: { $0.name.lowercased() == "duration" })?.value {
           let seconds = Self.parseDurationToSeconds(durationString)
           if let seconds {

--- a/LittleMoments/Core/NotificationManager.swift
+++ b/LittleMoments/Core/NotificationManager.swift
@@ -1,0 +1,88 @@
+//
+//  NotificationManager.swift
+//  Little Moments
+//
+//  Created for Swift 6 concurrency compliance
+//
+
+import Foundation
+import UserNotifications
+
+/// A Swift 6 concurrency-safe notification manager that handles authorization and scheduling
+/// without MainActor violations. This follows Option B from the MainActor crash specs.
+@MainActor
+final class NotificationManager {
+  static let shared = NotificationManager()
+
+  private init() {}
+
+  /// Request notification authorization using async/await (Swift 6 safe)
+  /// - Parameter options: The notification authorization options
+  /// - Returns: A tuple indicating if authorization was granted and any error
+  func requestAuthorization(
+    options: UNAuthorizationOptions = [.alert, .sound]
+  ) async -> (granted: Bool, error: Error?) {
+    let center = UNUserNotificationCenter.current()
+
+    do {
+      let granted = try await center.requestAuthorization(options: options)
+      return (granted, nil)
+    } catch {
+      return (false, error)
+    }
+  }
+
+  /// Check current notification authorization status
+  /// - Returns: The current authorization status
+  func getAuthorizationStatus() async -> UNAuthorizationStatus {
+    let center = UNUserNotificationCenter.current()
+    return await withCheckedContinuation { continuation in
+      center.getNotificationSettings { @Sendable settings in
+        continuation.resume(returning: settings.authorizationStatus)
+      }
+    }
+  }
+
+  /// Request authorization only if not yet determined (Swift 6 safe)
+  func requestAuthorizationIfNeeded() async {
+    let status = await getAuthorizationStatus()
+    guard status == .notDetermined else { return }
+
+    _ = await requestAuthorization()
+  }
+
+  /// Schedule a timer notification (non-isolated, safe to call from background)
+  nonisolated func scheduleTimerNotification(
+    identifier: String,
+    title: String,
+    body: String,
+    soundName: String,
+    timeInterval: TimeInterval
+  ) async throws {
+    let center = UNUserNotificationCenter.current()
+
+    let content = UNMutableNotificationContent()
+    content.title = title
+    content.body = body
+    content.sound = UNNotificationSound(named: UNNotificationSoundName(rawValue: soundName))
+    content.interruptionLevel = .timeSensitive
+
+    let trigger = UNTimeIntervalNotificationTrigger(
+      timeInterval: timeInterval,
+      repeats: false
+    )
+
+    let request = UNNotificationRequest(
+      identifier: identifier,
+      content: content,
+      trigger: trigger
+    )
+
+    try await center.add(request)
+  }
+
+  /// Remove all pending notifications (non-isolated)
+  nonisolated func removeAllPendingNotifications() {
+    UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+  }
+}

--- a/LittleMoments/Features/Meditation/Models/MeditationSessionIntent.swift
+++ b/LittleMoments/Features/Meditation/Models/MeditationSessionIntent.swift
@@ -4,8 +4,18 @@ import SwiftUI
 struct MeditationSessionIntent: AppIntent {
   static var title: LocalizedStringResource { "Start Meditation Session" }
 
+  @Parameter(title: "Duration", description: "Optional duration in minutes")
+  var durationMinutes: Int?
+
+  static var parameterSummary: some ParameterSummary {
+    Summary("Start a session for \(\.$durationMinutes) minutes")
+  }
+
   @MainActor
   func perform() async throws -> some IntentResult {
+    if let durationMinutes {
+      AppState.shared.pendingStartDurationSeconds = durationMinutes * 60
+    }
     AppState.shared.showTimerRunningView = true
     return .result()
   }

--- a/LittleMoments/Features/Meditation/Models/StartMeditationOpenIntent.swift
+++ b/LittleMoments/Features/Meditation/Models/StartMeditationOpenIntent.swift
@@ -7,6 +7,8 @@ import OSLog
 struct StartMeditationOpenIntent: AppIntent {
   static var title: LocalizedStringResource { "Start Meditation" }
   static var openAppWhenRun: Bool { true }
+  // Hide this Control/Widget-focused intent from Shortcuts to avoid duplicates
+  static var isDiscoverable: Bool { false }
 
   @MainActor
   func perform() async throws -> some IntentResult {

--- a/LittleMoments/Features/Settings/Models/JustNowSettings.swift
+++ b/LittleMoments/Features/Settings/Models/JustNowSettings.swift
@@ -21,11 +21,15 @@ final class JustNowSettings: ObservableObject {
     }
     set {
       if newValue {
-        HealthKitManager.shared.requestAuthorization { (success, error) in
+        HealthKitManager.shared.requestAuthorization { @Sendable (success, error) in
           if !success {
             print("HealthKit permission denied: ", error?.localizedDescription ?? "Unknown error")
             return
           }
+          // If we need to update UI state based on the result, use MainActor:
+          // Task { @MainActor in
+          //   // Update UI state here
+          // }
         }
       }
       userDefaults.set(newValue, forKey: "writeToHealth")

--- a/LittleMoments/Features/Timer/Models/TimerViewModel.swift
+++ b/LittleMoments/Features/Timer/Models/TimerViewModel.swift
@@ -237,7 +237,7 @@ class TimerViewModel: ObservableObject {
       OneTimeScheduledBellAlert(targetTimeInMin: 20),
       OneTimeScheduledBellAlert(targetTimeInMin: 30),
       OneTimeScheduledBellAlert(targetTimeInMin: 45),
-      OneTimeScheduledBellAlert(targetTimeInMin: 60)
+      OneTimeScheduledBellAlert(targetTimeInMin: 60),
     ]
 
     #if targetEnvironment(simulator)

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -38,7 +38,9 @@ struct TimerStartView: View {
           ImageButton(
             imageName: "play.fill", buttonText: "Start session",
             action: {
-              let intent = MeditationSessionIntent()
+              let intent = MeditationSessionIntent(
+                durationMinutes: appState.pendingStartDurationSeconds.map { $0 / 60 }
+              )
               // Print the intent I'm donating
               let donationManager = IntentDonationManager.shared
               // Donate the intent and print confirmation for debugging purposes depending on success or failure

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -59,11 +59,26 @@ struct TimerStartView: View {
       }
       .frame(maxHeight: .infinity)
     }
+    .onAppear {
+      // Request notification authorization the first time the main screen shows
+      // Keep this non-blocking and avoid touching SwiftUI state in callbacks
+      requestNotificationAuthorizationIfNeeded()
+    }
     .sheet(isPresented: $appState.showTimerRunningView) {
       TimerRunningView()
     }
     .sheet(isPresented: $appState.showSettingsView) {
       SettingsView()
+    }
+  }
+
+  private func requestNotificationAuthorizationIfNeeded() {
+    // Skip during stable UI tests
+    if ProcessInfo.processInfo.arguments.contains("-DISABLE_SYSTEM_INTEGRATIONS") { return }
+
+    // Use the async/await approach for Swift 6 compliance
+    Task {
+      await NotificationManager.shared.requestAuthorizationIfNeeded()
     }
   }
 }

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -38,9 +38,8 @@ struct TimerStartView: View {
           ImageButton(
             imageName: "play.fill", buttonText: "Start session",
             action: {
-              let intent = MeditationSessionIntent(
-                durationMinutes: appState.pendingStartDurationSeconds.map { $0 / 60 }
-              )
+              var intent = MeditationSessionIntent()
+              intent.durationMinutes = appState.pendingStartDurationSeconds.map { $0 / 60 }
               // Print the intent I'm donating
               let donationManager = IntentDonationManager.shared
               // Donate the intent and print confirmation for debugging purposes depending on success or failure

--- a/LittleMoments/Tests/UITests/Little_MomentsUITests.swift
+++ b/LittleMoments/Tests/UITests/Little_MomentsUITests.swift
@@ -29,7 +29,7 @@ final class LittleMomentsUITests: XCTestCase {
 
   func testExample() throws {
     // UI tests must launch the application that they test.
-    app.launchArguments = ["UITesting"]
+    app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
     app.launch()
 
     // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -39,6 +39,7 @@ final class LittleMomentsUITests: XCTestCase {
     if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
       // This measures how long it takes to launch your application.
       measure(metrics: [XCTApplicationLaunchMetric()]) {
+        app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
         app.launch()
       }
     }

--- a/LittleMoments/Tests/UITests/LiveActivityUITests.swift
+++ b/LittleMoments/Tests/UITests/LiveActivityUITests.swift
@@ -5,6 +5,7 @@ final class LiveActivityUITests: XCTestCase {
   func testLiveActivityAppears() {
     // Test that live activity appears when timer starts
     let app = XCUIApplication()
+    app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
     app.launch()
 
     // Navigate to timer and start it

--- a/LittleMoments/Tests/UITests/TimerFlowUITests.swift
+++ b/LittleMoments/Tests/UITests/TimerFlowUITests.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+@MainActor
+final class TimerFlowUITests: XCTestCase {
+  // No shared app instance; create within each test to avoid actor issues
+
+  func testStartSetTimeThenComplete() throws {
+    let app = XCUIApplication()
+    continueAfterFailure = false
+    registerNotificationPermissionMonitor(app: app)
+    app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
+    app.launch()
+    app.activate()
+
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 10))
+    app.buttons["Start session"].tap()
+
+    XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 10), "Timer sheet did not appear")
+
+    registerNotificationPermissionMonitor(app: app)
+    selectShortDuration(app: app)
+    // Trigger interruption handler if system alert appears
+    app.tap()
+
+    _ = XCTWaiter.wait(for: [expectation(description: "wait")], timeout: 3)
+
+    app.buttons["Complete"].tap()
+
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 3))
+  }
+
+  func testStartSetTimeThenCancel() throws {
+    let app = XCUIApplication()
+    continueAfterFailure = false
+    registerNotificationPermissionMonitor(app: app)
+    app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
+    app.launch()
+    app.activate()
+
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 10))
+    app.buttons["Start session"].tap()
+
+    XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 10), "Timer sheet did not appear")
+
+    registerNotificationPermissionMonitor(app: app)
+    selectShortDuration(app: app)
+    // Trigger interruption handler if system alert appears
+    app.tap()
+
+    _ = XCTWaiter.wait(for: [expectation(description: "wait")], timeout: 2)
+
+    app.buttons["Cancel"].tap()
+
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 3))
+  }
+
+  func testStartSetTimeWaitLongerThanTimerThenComplete() throws {
+    let app = XCUIApplication()
+    continueAfterFailure = false
+    registerNotificationPermissionMonitor(app: app)
+    app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
+    app.launch()
+    app.activate()
+
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 10))
+    app.buttons["Start session"].tap()
+
+    XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 10), "Timer sheet did not appear")
+
+    registerNotificationPermissionMonitor(app: app)
+    selectShortDuration(app: app)
+    // Trigger interruption handler if system alert appears
+    app.tap()
+
+    // Wait longer than the short timer (5 sec on simulator)
+    _ = XCTWaiter.wait(for: [expectation(description: "wait longer than timer")], timeout: 6.5)
+
+    app.buttons["Complete"].tap()
+
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 3))
+  }
+
+  private func selectShortDuration(app: XCUIApplication) {
+    if app.buttons["5 sec"].exists {
+      app.buttons["5 sec"].tap()
+    } else if app.buttons["1"].exists {
+      app.buttons["1"].tap()
+    }
+  }
+
+  private func registerNotificationPermissionMonitor(app: XCUIApplication) {
+    addUIInterruptionMonitor(withDescription: "Notifications") { alert in
+      if alert.buttons["Allow"].exists {
+        alert.buttons["Allow"].tap()
+        return true
+      }
+      if alert.buttons["Don’t Allow"].exists {
+        alert.buttons["Don’t Allow"].tap()
+        return true
+      }
+      if alert.buttons["Don't Allow"].exists {
+        alert.buttons["Don't Allow"].tap()
+        return true
+      }
+      return false
+    }
+  }
+}

--- a/LittleMoments/Tests/UITests/TimerIntegrationUITests.swift
+++ b/LittleMoments/Tests/UITests/TimerIntegrationUITests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@MainActor
+final class TimerIntegrationUITests: XCTestCase {
+  // This test intentionally does NOT pass -DISABLE_SYSTEM_INTEGRATIONS
+  // so it exercises the UNUserNotificationCenter authorization callback path.
+
+  func testSelectingDurationSchedulesNotification_NoCrash() throws {
+    let app = XCUIApplication()
+    continueAfterFailure = false
+
+    // Handle the notifications permission sheet if it appears
+    addUIInterruptionMonitor(withDescription: "Notifications") { alert in
+      if alert.buttons["Allow"].exists {
+        alert.buttons["Allow"].tap()
+        return true
+      }
+      if alert.buttons["Don’t Allow"].exists {
+        alert.buttons["Don’t Allow"].tap()
+        return true
+      }
+      if alert.buttons["Don't Allow"].exists {
+        alert.buttons["Don't Allow"].tap()
+        return true
+      }
+      return false
+    }
+
+    app.launchArguments = ["UITesting"]
+    app.launch()
+    app.activate()
+    // Trigger monitor immediately if permission alert shows on main screen
+    app.tap()
+
+    // Go into running view
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 10))
+    app.buttons["Start session"].tap()
+    XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 10))
+
+    // Tap a short duration to trigger scheduling + authorization callback
+    if app.buttons["5 sec"].waitForExistence(timeout: 2) {
+      app.buttons["5 sec"].tap()
+    } else if app.buttons["1"].waitForExistence(timeout: 2) {
+      app.buttons["1"].tap()
+    }
+
+    // Trigger interruption handler if the permission alert is shown
+    app.tap()
+
+    // Give things a moment; if the app crashes from thread violations,
+    // the test will fail with "application is not running".
+    _ = XCTWaiter.wait(for: [expectation(description: "settle")], timeout: 2.5)
+
+    // Complete to dismiss
+    app.buttons["Complete"].tap()
+    XCTAssertTrue(app.buttons["Start session"].waitForExistence(timeout: 5))
+  }
+}

--- a/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
+++ b/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
@@ -55,7 +55,8 @@ final class DeepLinkTests: XCTestCase {
 
   func testMeditationSessionIntentPerformWithDurationSetsPreset() {
     AppState.shared.resetState()
-    let intent = MeditationSessionIntent(durationMinutes: 2)
+    var intent = MeditationSessionIntent()
+    intent.durationMinutes = 2
     let exp = expectation(description: "intent perform")
     Task {
       _ = try? await intent.perform()

--- a/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
+++ b/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
@@ -53,6 +53,19 @@ final class DeepLinkTests: XCTestCase {
     XCTAssertTrue(AppState.shared.showTimerRunningView)
   }
 
+  func testMeditationSessionIntentPerformWithDurationSetsPreset() {
+    AppState.shared.resetState()
+    let intent = MeditationSessionIntent(durationMinutes: 2)
+    let exp = expectation(description: "intent perform")
+    Task {
+      _ = try? await intent.perform()
+      exp.fulfill()
+    }
+    wait(for: [exp], timeout: 2.0)
+    XCTAssertTrue(AppState.shared.showTimerRunningView)
+    XCTAssertEqual(AppState.shared.pendingStartDurationSeconds, 120)
+  }
+
   func testParseDurationHelper() throws {
     XCTAssertEqual(LittleMomentsApp.parseDurationToSeconds("60"), 60)
     XCTAssertEqual(LittleMomentsApp.parseDurationToSeconds("60s"), 60)

--- a/LittleMoments/WidgetExtension/MeditationLiveActivityView.swift
+++ b/LittleMoments/WidgetExtension/MeditationLiveActivityView.swift
@@ -36,22 +36,26 @@ struct MeditationLiveActivityView: View {
 
         // Use links instead of buttons for deep linking
         HStack(spacing: 12) {
-          Link(destination: URL(string: "littlemoments://finishSession")!) {
-            Text("Finish")
-              .frame(maxWidth: .infinity)
-              .padding(.vertical, 6)
-              .background(Color.green.opacity(0.2))
-              .cornerRadius(8)
-              .foregroundColor(.green)
+          if let url = URL(string: "littlemoments://finishSession") {
+            Link(destination: url) {
+              Text("Finish")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+                .background(Color.green.opacity(0.2))
+                .cornerRadius(8)
+                .foregroundColor(.green)
+            }
           }
 
-          Link(destination: URL(string: "littlemoments://cancelSession")!) {
-            Text("Cancel")
-              .frame(maxWidth: .infinity)
-              .padding(.vertical, 6)
-              .background(Color.red.opacity(0.2))
-              .cornerRadius(8)
-              .foregroundColor(.red)
+          if let url = URL(string: "littlemoments://cancelSession") {
+            Link(destination: url) {
+              Text("Cancel")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+                .background(Color.red.opacity(0.2))
+                .cornerRadius(8)
+                .foregroundColor(.red)
+            }
           }
         }
       }

--- a/LittleMoments/WidgetExtension/StartMeditationWidget.swift
+++ b/LittleMoments/WidgetExtension/StartMeditationWidget.swift
@@ -145,8 +145,15 @@ private struct StartMeditationWidgetView: View {
   // Small helper to produce a duration chip that opens the app with a preset timer
   private func durationChip(seconds: Int) -> some View {
     let minutes = seconds % 60 == 0 ? seconds / 60 : nil
-    let numberText = minutes != nil ? String(minutes!) : String(seconds)
-    let suffix = minutes != nil ? "m" : "s"
+    let numberText: String
+    let suffix: String
+    if let minutesVal = minutes {
+      numberText = String(minutesVal)
+      suffix = "m"
+    } else {
+      numberText = String(seconds)
+      suffix = "s"
+    }
     return safeLink("littlemoments://startSession?duration=\(seconds)") {
       HStack(alignment: .firstTextBaseline, spacing: 1) {
         Text(numberText)

--- a/LittleMoments/WidgetExtension/WidgetBundle.swift
+++ b/LittleMoments/WidgetExtension/WidgetBundle.swift
@@ -48,23 +48,27 @@ struct MeditationLiveActivityWidget: Widget {
         DynamicIslandExpandedRegion(.bottom) {
           HStack(spacing: 12) {
             // Complete session link
-            Link(destination: URL(string: "littlemoments://finishSession")!) {
-              Label("Complete", systemImage: "checkmark.circle.fill")
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(Color.green.opacity(0.2))
-                .cornerRadius(8)
-                .foregroundColor(.green)
+            if let url = URL(string: "littlemoments://finishSession") {
+              Link(destination: url) {
+                Label("Complete", systemImage: "checkmark.circle.fill")
+                  .frame(maxWidth: .infinity)
+                  .padding(.vertical, 6)
+                  .background(Color.green.opacity(0.2))
+                  .cornerRadius(8)
+                  .foregroundColor(.green)
+              }
             }
 
             // Cancel session link
-            Link(destination: URL(string: "littlemoments://cancelSession")!) {
-              Label("Cancel", systemImage: "xmark.circle.fill")
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(Color.red.opacity(0.2))
-                .cornerRadius(8)
-                .foregroundColor(.red)
+            if let url = URL(string: "littlemoments://cancelSession") {
+              Link(destination: url) {
+                Label("Cancel", systemImage: "xmark.circle.fill")
+                  .frame(maxWidth: .infinity)
+                  .padding(.vertical, 6)
+                  .background(Color.red.opacity(0.2))
+                  .cornerRadius(8)
+                  .foregroundColor(.red)
+              }
             }
           }
           .padding(.horizontal)
@@ -126,22 +130,26 @@ struct MeditationLiveActivityWidget: Widget {
 
           // Use links instead of buttons for deep linking
           HStack(spacing: 12) {
-            Link(destination: URL(string: "littlemoments://finishSession")!) {
-              Text("Finish")
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(Color.green.opacity(0.2))
-                .cornerRadius(8)
-                .foregroundColor(.green)
+            if let url = URL(string: "littlemoments://finishSession") {
+              Link(destination: url) {
+                Text("Finish")
+                  .frame(maxWidth: .infinity)
+                  .padding(.vertical, 6)
+                  .background(Color.green.opacity(0.2))
+                  .cornerRadius(8)
+                  .foregroundColor(.green)
+              }
             }
 
-            Link(destination: URL(string: "littlemoments://cancelSession")!) {
-              Text("Cancel")
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(Color.red.opacity(0.2))
-                .cornerRadius(8)
-                .foregroundColor(.red)
+            if let url = URL(string: "littlemoments://cancelSession") {
+              Link(destination: url) {
+                Text("Cancel")
+                  .frame(maxWidth: .infinity)
+                  .padding(.vertical, 6)
+                  .background(Color.red.opacity(0.2))
+                  .cornerRadius(8)
+                  .foregroundColor(.red)
+              }
             }
           }
         }

--- a/Project.swift
+++ b/Project.swift
@@ -1,4 +1,7 @@
 import ProjectDescription
+// swiftlint:disable trailing_comma
+// Explanation: Tuist manifests intentionally use trailing commas for
+// readability and cleaner diffs. We disable only this rule for this file.
 
 let marketingVersion = "0.2.0"
 let buildVersion = "51"
@@ -8,7 +11,7 @@ let baseSettings: [String: SettingValue] = [
   "CURRENT_PROJECT_VERSION": .string(buildVersion),
   "DEVELOPMENT_TEAM": .string("Z5NU48NAF9"),
   // Adopt Swift 6 across all targets
-  "SWIFT_VERSION": .string("6.0"),
+  "SWIFT_VERSION": .string("6.0")
 ]
 
 let project = Project(
@@ -19,13 +22,14 @@ let project = Project(
       destinations: .iOS,
       product: .app,
       bundleId: "net.bomash.illya.LittleMoments",
+      deploymentTargets: .iOS("17.0"),
       infoPlist: .file(path: "Little-Moments-Info.plist"),
       sources: [
         "LittleMoments/Core/**",
         "LittleMoments/Features/**",
         "LittleMoments/App/iOS/**",
         // Exclude files that are part of the widget extension
-        "!LittleMoments/Features/LiveActivity/Views/LiveActivityWidgetBundle.swift",
+        "!LittleMoments/Features/LiveActivity/Views/LiveActivityWidgetBundle.swift"
       ],
       resources: ["LittleMoments/Resources/**"],
       entitlements: .file(path: "Little Moments.entitlements"),
@@ -34,7 +38,7 @@ let project = Project(
         .sdk(name: "SwiftUI", type: .framework),
         .sdk(name: "WidgetKit", type: .framework),
         .sdk(name: "ActivityKit", type: .framework),
-        .sdk(name: "UIKit", type: .framework),
+        .sdk(name: "UIKit", type: .framework)
       ],
       settings: .settings(
         base: baseSettings,
@@ -46,16 +50,18 @@ let project = Project(
               "SUPPORTS_MACCATALYST": "NO",
               "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
               "CODE_SIGN_ENTITLEMENTS": "Little Moments.entitlements",
-              "CODE_SIGN_STYLE": "Automatic",
-            ]),
+              "CODE_SIGN_STYLE": "Automatic"
+            ]
+          ),
           .release(
             name: "Release",
             settings: [
               "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator",
               "SUPPORTS_MACCATALYST": "NO",
               "CODE_SIGN_ENTITLEMENTS": "Little Moments.entitlements",
-              "CODE_SIGN_STYLE": "Automatic",
-            ]),
+              "CODE_SIGN_STYLE": "Automatic"
+            ]
+          ),
         ]
       ),
       additionalFiles: []
@@ -67,6 +73,7 @@ let project = Project(
       product: .appExtension,
       productName: "LittleMomentsWidgetExtension",
       bundleId: "net.bomash.illya.LittleMoments.WidgetExtension",
+      deploymentTargets: .iOS("17.0"),
       infoPlist: .file(path: "LittleMoments/WidgetExtension/WidgetExtension-Info.plist"),
       sources: ["LittleMoments/WidgetExtension/**"],
       resources: ["LittleMoments/Resources/**"],
@@ -75,7 +82,7 @@ let project = Project(
       dependencies: [
         .sdk(name: "SwiftUI", type: .framework),
         .sdk(name: "WidgetKit", type: .framework),
-        .sdk(name: "ActivityKit", type: .framework),
+        .sdk(name: "ActivityKit", type: .framework)
       ],
       settings: .settings(
         base: baseSettings,
@@ -87,7 +94,7 @@ let project = Project(
                 "LittleMoments/WidgetExtension/LittleMomentsWidgetExtension.entitlements",
               "CODE_SIGN_STYLE": "Automatic",
               "PROVISIONING_PROFILE_SPECIFIER": "",
-              "CODE_SIGN_IDENTITY": "Apple Development",
+              "CODE_SIGN_IDENTITY": "Apple Development"
             ]
           ),
           .release(
@@ -97,7 +104,7 @@ let project = Project(
                 "LittleMoments/WidgetExtension/LittleMomentsWidgetExtension.entitlements",
               "CODE_SIGN_STYLE": "Automatic",
               "PROVISIONING_PROFILE_SPECIFIER": "",
-              "CODE_SIGN_IDENTITY": "Apple Development",
+              "CODE_SIGN_IDENTITY": "Apple Development"
             ]
           ),
         ]
@@ -108,6 +115,7 @@ let project = Project(
       destinations: .iOS,
       product: .unitTests,
       bundleId: "net.bomash.illya.LittleMomentsTests",
+      deploymentTargets: .iOS("17.0"),
       infoPlist: .default,
       sources: ["LittleMoments/Tests/UnitTests/**"],
       dependencies: [
@@ -121,6 +129,7 @@ let project = Project(
       destinations: .iOS,
       product: .uiTests,
       bundleId: "net.bomash.illya.LittleMomentsUITests",
+      deploymentTargets: .iOS("17.0"),
       infoPlist: .default,
       sources: ["LittleMoments/Tests/UITests/**"],
       dependencies: [
@@ -169,3 +178,4 @@ let project = Project(
     ),
   ]
 )
+// swiftlint:enable trailing_comma

--- a/Project.swift
+++ b/Project.swift
@@ -1,4 +1,5 @@
 import ProjectDescription
+
 // swiftlint:disable trailing_comma
 // Explanation: Tuist manifests intentionally use trailing commas for
 // readability and cleaner diffs. We disable only this rule for this file.
@@ -11,7 +12,7 @@ let baseSettings: [String: SettingValue] = [
   "CURRENT_PROJECT_VERSION": .string(buildVersion),
   "DEVELOPMENT_TEAM": .string("Z5NU48NAF9"),
   // Adopt Swift 6 across all targets
-  "SWIFT_VERSION": .string("6.0")
+  "SWIFT_VERSION": .string("6.0"),
 ]
 
 let project = Project(
@@ -29,7 +30,7 @@ let project = Project(
         "LittleMoments/Features/**",
         "LittleMoments/App/iOS/**",
         // Exclude files that are part of the widget extension
-        "!LittleMoments/Features/LiveActivity/Views/LiveActivityWidgetBundle.swift"
+        "!LittleMoments/Features/LiveActivity/Views/LiveActivityWidgetBundle.swift",
       ],
       resources: ["LittleMoments/Resources/**"],
       entitlements: .file(path: "Little Moments.entitlements"),
@@ -38,7 +39,7 @@ let project = Project(
         .sdk(name: "SwiftUI", type: .framework),
         .sdk(name: "WidgetKit", type: .framework),
         .sdk(name: "ActivityKit", type: .framework),
-        .sdk(name: "UIKit", type: .framework)
+        .sdk(name: "UIKit", type: .framework),
       ],
       settings: .settings(
         base: baseSettings,
@@ -50,7 +51,7 @@ let project = Project(
               "SUPPORTS_MACCATALYST": "NO",
               "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
               "CODE_SIGN_ENTITLEMENTS": "Little Moments.entitlements",
-              "CODE_SIGN_STYLE": "Automatic"
+              "CODE_SIGN_STYLE": "Automatic",
             ]
           ),
           .release(
@@ -59,7 +60,7 @@ let project = Project(
               "SUPPORTED_PLATFORMS": "iphoneos iphonesimulator",
               "SUPPORTS_MACCATALYST": "NO",
               "CODE_SIGN_ENTITLEMENTS": "Little Moments.entitlements",
-              "CODE_SIGN_STYLE": "Automatic"
+              "CODE_SIGN_STYLE": "Automatic",
             ]
           ),
         ]
@@ -82,7 +83,7 @@ let project = Project(
       dependencies: [
         .sdk(name: "SwiftUI", type: .framework),
         .sdk(name: "WidgetKit", type: .framework),
-        .sdk(name: "ActivityKit", type: .framework)
+        .sdk(name: "ActivityKit", type: .framework),
       ],
       settings: .settings(
         base: baseSettings,
@@ -94,7 +95,7 @@ let project = Project(
                 "LittleMoments/WidgetExtension/LittleMomentsWidgetExtension.entitlements",
               "CODE_SIGN_STYLE": "Automatic",
               "PROVISIONING_PROFILE_SPECIFIER": "",
-              "CODE_SIGN_IDENTITY": "Apple Development"
+              "CODE_SIGN_IDENTITY": "Apple Development",
             ]
           ),
           .release(
@@ -104,7 +105,7 @@ let project = Project(
                 "LittleMoments/WidgetExtension/LittleMomentsWidgetExtension.entitlements",
               "CODE_SIGN_STYLE": "Automatic",
               "PROVISIONING_PROFILE_SPECIFIER": "",
-              "CODE_SIGN_IDENTITY": "Apple Development"
+              "CODE_SIGN_IDENTITY": "Apple Development",
             ]
           ),
         ]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,7 @@ platform :ios do
   desc "Run SwiftLint"
   lane :lint do
     swiftlint(
+      config_file: ".swiftlint.yml",
       quiet: true,
       strict: true,
       ignore_exit_status: true

--- a/specs/2025-09-13-notification-mainactor-crash.md
+++ b/specs/2025-09-13-notification-mainactor-crash.md
@@ -1,0 +1,278 @@
+# Swift 6 Concurrency Issues with UNUserNotificationCenter
+
+Date: 2025-09-13
+
+## Summary
+
+After migrating to Swift 6, the app can crash when tapping a timer preset because SwiftUI/MainActor–isolated code is touched from a `UNUserNotificationCenter` background callback. Apple’s user notification authorization and scheduling APIs invoke completions on a private background queue; any access to `@MainActor`-isolated state inside those completions must hop to the MainActor first. Additionally, system completion handlers should be marked `@Sendable` under Swift 6’s stricter concurrency rules.
+
+## Root Cause
+
+Swift 6 enforces stricter concurrency rules:
+- System completion handlers (notifications, HealthKit) run on background queues
+- These handlers must be marked `@Sendable` to be concurrency-safe
+- Any access to `@MainActor`-isolated state from these handlers requires explicit MainActor hopping
+- `UNNotificationSettings` is not `Sendable`, so async/await wrappers must use continuation patterns
+
+## Specific Issues Fixed
+
+### 1. TimerStartView notification authorization
+**Problem:** Completion handlers not marked `@Sendable`
+```swift
+// ❌ Before (Swift 6 error)
+center.getNotificationSettings { settings in
+  center.requestAuthorization(options: [.alert, .sound]) { _, _ in
+```
+
+**Solution:** Use async/await with NotificationManager
+```swift
+// ✅ After (Swift 6 compliant)
+Task {
+  await NotificationManager.shared.requestAuthorizationIfNeeded()
+}
+```
+
+### 2. HealthKit authorization callback
+**Problem:** Completion handler not marked `@Sendable`
+```swift
+// ❌ Before
+HealthKitManager.shared.requestAuthorization { (success, error) in
+```
+
+**Solution:** Mark callback as `@Sendable`
+```swift
+// ✅ After
+HealthKitManager.shared.requestAuthorization { @Sendable (success, error) in
+```
+
+### 3. Notification scheduling
+**Problem:** Synchronous API call could block MainActor
+```swift
+// ❌ Before
+UNUserNotificationCenter.current().add(request)
+```
+
+**Solution:** Use async version
+```swift
+// ✅ After
+Task {
+  try? await UNUserNotificationCenter.current().add(request)
+}
+```
+
+### 4. Tests flaking due to system surfaces
+**Problem:** UI tests were flaking due to OS permission surfaces and Live Activities.
+
+**Solution:** Add a `-DISABLE_SYSTEM_INTEGRATIONS` launch argument and guard notification scheduling and Live Activities in code paths used by tests.
+
+## Current Implementation (as of 2025-09-13)
+
+### Architecture
+- Created `NotificationManager` for centralized, concurrency-safe notification handling
+- Request authorization on first main screen show (`TimerStartView.onAppear`)
+- Schedule notifications best-effort (iOS drops unauthorized notifications)
+- All system completion handlers marked `@Sendable`
+
+### Files Modified
+- `TimerStartView.swift` - Updated to use async notification authorization
+- `JustNowSettings.swift` - Added `@Sendable` to HealthKit callback
+- `TimerRunningView.swift` - Updated notification scheduling to use async/await
+- Created `NotificationManager.swift` - Swift 6 compliant notification manager
+- Moved example code into this spec as reference documentation (and removed example source from the app target)
+
+### Swift 6 Concurrency Rules Applied
+1. ✅ Mark completion handlers as `@Sendable`
+2. ✅ Use `Task { @MainActor in ... }` to hop back to MainActor when needed
+3. ✅ Prefer async/await over callbacks for new code
+4. ✅ Use `nonisolated` functions for background work
+5. ❌ Never access `@MainActor` properties directly from system callbacks
+
+## Future Considerations
+
+The notification permission request could potentially be moved to a more strategic location in the user flow, such as:
+- During onboarding when explaining timer notifications
+- Just before the user's first attempt to schedule a notification
+- In settings when the user enables notification-related features
+
+This would provide better UX by explaining the purpose of the permission before requesting it.
+
+## Test Strategy
+
+Integration UI test (`TimerIntegrationUITests`) exercises the authorization path without `-DISABLE_SYSTEM_INTEGRATIONS` to catch MainActor violations and crashes.
+
+## Why It Crashes
+
+- `UNUserNotificationCenter` completions and delegate methods run on a background queue.
+- `@Published` properties in `TimerViewModel`, `AppState.showTimerRunningView`, and other `@MainActor` APIs must be accessed on the MainActor.
+- When the background completion directly updates those properties or calls `@MainActor` APIs, Swift’s concurrency runtime detects crossing actor boundaries incorrectly and asserts.
+
+## Desired Threading Model (What should happen)
+
+1) UI action (SwiftUI Button) runs on MainActor.
+2) MainActor updates SwiftUI state (e.g., set selected duration) before any background calls.
+3) Off-main work (requesting permission, scheduling the notification) runs on a background queue.
+4) Any subsequent UI/MainActor updates happen only via an explicit MainActor hop (e.g., `await MainActor.run { ... }` or `Task { @MainActor in ... }`).
+
+## Observed Problem Areas
+
+- `UNUserNotificationCenter.requestAuthorization` completion previously changed UI/model state directly.
+- Any future additions to that completion (e.g., to show banners, persist state) can reintroduce the bug if not MainActor-hopped.
+
+## Approaches to Fix (Design Options)
+
+### Option A: Minimal fix (wrap completion in MainActor)
+
+- Wrap the authorization completion (and any future `UN...` completions) with `Task { @MainActor in ... }` before touching any `@MainActor` state.
+- Pros: Smallest change; easy to reason about; minimal code churn.
+- Cons: Easy to regress if future edits add state changes outside the MainActor hop; still mixes callback-style APIs with MainActor code.
+
+### Option B: Use async/await wrappers for UN APIs (preferred)
+
+- Replace callback-based APIs with async wrappers:
+  - e.g., wrap `requestAuthorization` with `withCheckedContinuation` and expose an `async` function.
+  - Similarly wrap `add(request:)` if you need completion handling.
+- Perform scheduling inside a detached `Task` or a nonisolated context that doesn’t capture `@MainActor` state; only hop to MainActor when updating SwiftUI state.
+- Pros: Structured concurrency clarifies where suspension occurs; fewer callback queues; easier to enforce "no MainActor touches" in background code.
+- Cons: Requires refactoring to async functions; need to ensure no MainActor state is captured inadvertently in tasks.
+
+### Option C: Extract a NotificationScheduler service (actor or class)
+
+- Create a `NotificationScheduler` component not annotated with `@MainActor` that owns all notification logic.
+- Expose an `async` API (e.g., `scheduleTimerNotification(duration: Int) async throws`).
+- UI layer calls it from MainActor; the scheduler runs off-main and never touches UI state; upon completion, the caller may hop to MainActor if needed.
+- Pros: Clear separation; easier unit testing with protocol + fake; avoids UI-state in system callbacks completely.
+- Cons: Slightly more boilerplate and DI; coordination required to report errors back to UI.
+
+### Option D: Centralize all UI state mutations
+
+- Keep all state changes before/after scheduling (never inside system callbacks). Any callback should only perform non-UI work (e.g., building requests, logging). If any UI state must change based on callback results, publish via `MainActor.run`.
+- Pros: Keeps UI logic linearly on the MainActor.
+- Cons: Sometimes you really do need to react to callback outcomes (e.g., permission denied) and must carefully hop to MainActor.
+
+## Test Strategy
+
+1) UI Flow (stable): existing `TimerFlowUITests` use `-DISABLE_SYSTEM_INTEGRATIONS` to avoid flakiness from OS surfaces and validate core flow.
+2) UI Integration (crash-catcher): `TimerIntegrationUITests` runs without that flag and exercises the authorization path on main screen show (permission sheet), and then the scheduling path when a duration is selected; the test fails if the app crashes.
+3) Unit Tests: Prefer adding a `NotificationScheduler` protocol and test double to assert `add(request)` is invoked with expected trigger/content.
+
+---
+
+## Appendix: Swift 6 Notification Examples
+
+The following examples demonstrate two safe patterns in Swift 6 for requesting notification permissions and scheduling notifications without violating MainActor isolation.
+
+```swift
+//
+//  Swift6NotificationExamples.swift
+//  Little Moments
+//
+//  Reference examples for handling notification permissions in Swift 6
+//
+
+import Foundation
+import UserNotifications
+
+// MARK: - Option A: Minimal Fix (Callback + @Sendable + MainActor.run)
+
+class CallbackApproach {
+  @MainActor
+  func requestNotificationPermissionCallback() {
+    let center = UNUserNotificationCenter.current()
+
+    center.getNotificationSettings { @Sendable settings in
+      guard settings.authorizationStatus == .notDetermined else { return }
+
+      center.requestAuthorization(options: [.alert, .sound]) { @Sendable granted, _ in
+        // ✅ Safe: No UI state access here
+        print("Authorization granted: \(granted)")
+
+        // ❌ BAD: This would crash in Swift 6
+        // self.someUIProperty = granted
+
+        // ✅ GOOD: If you need to update UI, hop to MainActor
+        if granted {
+          Task { @MainActor in
+            // Update UI state here safely
+            print("Can now update UI on MainActor")
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Option B: Async/Await Approach (Recommended)
+
+@MainActor
+class AsyncApproach {
+  func requestNotificationPermissionAsync() async {
+    let center = UNUserNotificationCenter.current()
+
+    // Check current status using callback approach for Swift 6 compliance
+    let authStatus = await withCheckedContinuation { continuation in
+      center.getNotificationSettings { @Sendable settings in
+        continuation.resume(returning: settings.authorizationStatus)
+      }
+    }
+
+    guard authStatus == .notDetermined else { return }
+
+    do {
+      // Request authorization using async/await
+      let granted = try await center.requestAuthorization(options: [.alert, .sound])
+
+      // ✅ Safe: We're already on MainActor, can update UI directly
+      print("Authorization granted: \(granted)")
+      // self.someUIProperty = granted // This would be safe here
+
+    } catch {
+      print("Authorization failed: \(error)")
+    }
+  }
+
+  // Alternative: Non-isolated function for use from background
+  nonisolated func scheduleNotificationFromBackground() async {
+    let center = UNUserNotificationCenter.current()
+
+    let content = UNMutableNotificationContent()
+    content.title = "Timer Complete"
+    content.body = "Your session has finished"
+
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+    let request = UNNotificationRequest(identifier: "test", content: content, trigger: trigger)
+
+    try? await center.add(request)
+
+    // If we need to update UI after scheduling:
+    await MainActor.run {
+      print("Notification scheduled, updating UI on MainActor")
+    }
+  }
+}
+
+// MARK: - Key Swift 6 Concurrency Rules for Notifications
+
+/*
+ 1. ✅ Always mark completion handlers as @Sendable
+ 2. ✅ Use Task { @MainActor in ... } to hop back to MainActor when needed
+ 3. ✅ Prefer async/await over callbacks for new code
+ 4. ✅ Mark functions as nonisolated if they don't need MainActor isolation
+ 5. ❌ Never access @MainActor properties directly from system callbacks
+ 6. ❌ Never call @MainActor methods directly from background queues
+
+ Swift 6 enforces these rules at compile time and runtime, preventing
+ the MainActor violations that could cause crashes in previous versions.
+ */
+```
+
+## Recommendation
+
+- Starting point: Keep the current approach (ask on main screen show; schedule best‑effort on selection).
+- Next iteration (preferred): Implement Option C (NotificationScheduler) and/or use async wrappers (Option B) so notification logic is isolated, testable, and never touches UI state.
+- Keep the integration UI test to guard against regressions.
+
+## Acceptance Criteria
+
+- No MainActor violations during notification authorization or scheduling.
+- Integration UI test passes without `-DISABLE_SYSTEM_INTEGRATIONS`.
+- Unit tests cover scheduling logic via a test double (if Option C is implemented).


### PR DESCRIPTION
## Summary
- add optional duration parameter to meditation session app intent
- donate duration with start view intents
- cover intent duration with a unit test
- accept duration in minutes and convert to seconds

## Testing
- `fastlane format_code` *(fails: command not found)*
- `fastlane lint` *(fails: command not found)*
- `fastlane test_unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e4b0584c8328b7a7f265592f5ae9