### PR TITLE
Update HealthKit unavailable edge case behavior

### DIFF
--- a/specs/2025-03-04-health-integration.md
+++ b/specs/2025-03-04-health-integration.md
@@ -68,7 +68,7 @@ Seamlessly record all meditation sessions to Apple Health (when enabled) without
 
 ### Edge Cases
 - If user denies HealthKit permissions, the toggle remains on but sessions aren't recorded
-- If HealthKit is unavailable on the device, the toggle is disabled
+- If HealthKit is unavailable on the device, the toggle stays enabled but any attempt to write simply fails
 - If writing to HealthKit fails, the app logs the error but doesn't notify the user
 
 ## Implementation Considerations


### PR DESCRIPTION
## Summary
- update the Health integration PRD to clarify that the settings toggle remains enabled when HealthKit is unavailable and writes simply fail

## Testing
- fastlane format_code *(fails: command not found)*
- fastlane lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c84c0514c0832883daf23b6bac5aaf