### PR TITLE
docs: Add specification maintenance guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,3 +143,8 @@ Follow conventional commit format: `type(scope): description`
 ## PRD Standards
 
 Product Requirement Documents must be placed in `specs/` directory with naming convention `YYYY-MM-DD-feature-name.md`. Use the template in `specs/TEMPLATE-feature-name.md`. Always run `date +%Y-%m-%d` to get current date before creating PRDs.
+
+## Specification Maintenance
+
+- For every feature PR, review the relevant documents in the `specs/` directory and update them when behavior or requirements change.
+- When a PR touches feature logic, explicitly mention in the PR description whether the related specification documents were updated or confirmed as still accurate.


### PR DESCRIPTION
## Summary
- add a Specification Maintenance section to AGENTS guidelines
- require feature PRs to review specs and note whether related documents were updated

## Testing
- fastlane format_code *(fails: command not found in container)*
- fastlane lint *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c84c429eac83288df90a635bb94b81