### PR TITLE
docs: add specs for pending test coverage

### DIFF
--- a/specs/todo/tech-debt/app-shortcuts-provider-unit-tests.md
+++ b/specs/todo/tech-debt/app-shortcuts-provider-unit-tests.md
@@ -1,0 +1,37 @@
+# Spec: AppShortcutsProvider Unit Tests
+
+## Objective
+Guarantee the Siri/App Shortcuts configuration remains discoverable and accurate by covering `LittleMomentsShortcuts.appShortcuts` with deterministic tests.
+
+## Current Gaps
+- No tests confirm the provider emits a single `AppShortcut` wired to `MeditationSessionIntent`.
+- Synonym phrases could regress (e.g., typos, missing `\(.applicationName)` token) without any automated failure.
+- Shortcut metadata such as `shortTitle` and `systemImageName` is unprotected.
+- Future additions to the shortcut array could break expectations without surfacing in review.
+
+## Proposed Test Coverage
+- Ensure `appShortcuts` returns exactly one shortcut by default.
+- Validate the shortcut’s intent is `MeditationSessionIntent` and that creating the intent does not crash under test.
+- Assert the `phrases` collection matches the expected four strings, including the embedded `\(.applicationName)` placeholder for App Shortcuts discoverability.
+- Verify `shortTitle` equals “Start Meditation” and `systemImageName` is `play.circle.fill`.
+- (Optional) Validate `AppShortcutsMetadata` remains stable by snapshotting to a lightweight codable struct if API churn makes direct comparisons fragile.
+
+## Implementation Plan
+1. **Expose Test Surface**
+   - Because `AppShortcutsProvider` is a pure static array, tests can instantiate `LittleMomentsShortcuts.appShortcuts` directly; ensure the production module is compiled for tests via `@testable import`.
+
+2. **Write Deterministic Assertions**
+   - Add a `LittleMomentsShortcutsTests` XCTestCase validating array count, intent type, phrases, and metadata.
+   - Use `XCTAssertEqual` for arrays to guarantee order (mirroring App Shortcuts presentation).
+
+3. **Guard Future Changes**
+   - Add a regression test that fails if additional shortcuts are appended without test updates, prompting reviewers to consider coverage for new intents.
+
+## Dependencies & Tooling
+- `XCTest`
+- AppIntents framework (already linked for the target)
+
+## Acceptance Criteria
+- Tests fail if any of the shortcut phrases, metadata, or intent assignments change unexpectedly.
+- Running the test suite does not hit live Siri/App Shortcuts APIs.
+- Future shortcut additions require explicit test updates, ensuring coverage evolves with new intents.

--- a/specs/todo/tech-debt/notification-manager-unit-tests.md
+++ b/specs/todo/tech-debt/notification-manager-unit-tests.md
@@ -1,0 +1,54 @@
+# Spec: NotificationManager Unit Tests
+
+## Objective
+Add targeted unit coverage for the concurrency-safe `NotificationManager` so we can confidently request notification authorization, inspect authorization status, and schedule or clear timer alerts without relying on the simulator or real notification center.
+
+## Current Gaps
+- No automated verification of the async `requestAuthorization` pathways (success vs. thrown error).
+- `getAuthorizationStatus()` bridging to `UNUserNotificationCenter.getNotificationSettings` lacks coverage to ensure the continuation resumes with the expected status.
+- `requestAuthorizationIfNeeded()` is untested, so regressions could cause duplicate prompts or skipped authorization.
+- `scheduleTimerNotification` is untested, leaving the content payload, trigger configuration, and error propagation unchecked.
+- `removeAllPendingNotifications()` currently hits the live notification center in production code with no guardrails for future refactors.
+
+## Proposed Test Coverage
+### Authorization Requests
+- **Success Path**: When the injected notification center returns `true`, `requestAuthorization` should surface `(granted: true, error: nil)`.
+- **Failure Path**: When the underlying call throws, `requestAuthorization` should surface `(granted: false, error: TestError)`.
+
+### Authorization Status + Conditional Prompting
+- Verify `getAuthorizationStatus` relays the status returned by the notification center stub.
+- Ensure `requestAuthorizationIfNeeded` calls `requestAuthorization` only when the status is `.notDetermined` and skips any additional work for `.denied`, `.authorized`, or `.provisional`.
+
+### Scheduling
+- Confirm `scheduleTimerNotification` forwards the identifier, title, body, sound name, and interval into the produced `UNNotificationRequest` and that `add` is invoked once.
+- Validate errors thrown from the underlying `add` method propagate to the caller (allowing tests to catch misconfigured requests).
+
+### Cleanup
+- Assert `removeAllPendingNotifications` delegates to the injected notification center exactly once.
+
+## Implementation Plan
+1. **Introduce Dependency Injection**
+   - Define a lightweight `UserNotificationCentering` protocol that exposes the subset of APIs used (`requestAuthorization`, `getNotificationSettings`, `add`, `removeAllPendingNotificationRequests`).
+   - Update `NotificationManager` to accept a dependency (defaulting to `UNUserNotificationCenter.current()`) so tests can inject a deterministic stub.
+
+2. **Build Test Doubles**
+   - Create a `UserNotificationCenterSpy` that captures method invocations, returns canned responses, and can simulate thrown errors.
+   - Supply async helpers that fulfill continuations deterministically (e.g., providing the desired `UNAuthorizationStatus`).
+
+3. **Write XCTest Cases**
+   - Cover each scenario outlined above using the spy.
+   - Exercise `scheduleTimerNotification` from a background Task to ensure the nonisolated API remains testable without MainActor hops.
+
+4. **Guard Against Regressions**
+   - Add negative tests ensuring that `requestAuthorizationIfNeeded` does **not** call the spy when status is not `.notDetermined`.
+   - Verify the spy records exactly one call for remove-all.
+
+## Dependencies & Tooling
+- `XCTest`
+- New protocol types (should live inside the production target).
+- Requires `@testable import LittleMoments`.
+
+## Acceptance Criteria
+- All new tests pass and fail without flakiness when the underlying implementation regresses.
+- `NotificationManager` can be safely refactored without invoking the real `UNUserNotificationCenter` during unit tests.
+- Coverage includes both success and failure paths for every public API in `NotificationManager`.

--- a/specs/todo/tech-debt/testing-strategy.md
+++ b/specs/todo/tech-debt/testing-strategy.md
@@ -2,7 +2,7 @@
 
 ## Context and Current State
 
-The current testing approach in the Little Moments app has significantly improved with recent Live Activity work, but still has areas for expansion. While there is comprehensive testing for Live Activity functionality and `TimerViewModel`, many key components remain untested, including `HealthKitManager`, `SoundManager`, and most UI components.
+The current testing approach in the Little Moments app has significantly improved with recent Live Activity work, but still has areas for expansion. While there is comprehensive testing for Live Activity functionality, `TimerViewModel`, `HealthKitManager`, and `SoundManager`, many key components remain untested, including `NotificationManager`, `AppShortcutsProvider`, background task helpers, and most UI components.
 
 ### Recently Completed (January 2025)
 - ✅ **Comprehensive Live Activity test suite implemented**
@@ -19,11 +19,20 @@ The current testing approach in the Little Moments app has significantly improve
   - Enabled seamless development workflow across team members
 
 ### Current Issues Remaining
-- Limited test coverage for core components (HealthKitManager, SoundManager)
+- Limited test coverage for remaining core services:
+  - [NotificationManager unit tests](./notification-manager-unit-tests.md)
+  - [AppShortcutsProvider unit tests](./app-shortcuts-provider-unit-tests.md)
+  - [Timer background task lifecycle tests](./timer-background-task-tests.md)
+- Most UI flows lack automation, and UI logic is still coupled to view code ([Timer UI flow UI tests](./timer-ui-flow-ui-tests.md))
 - No tests for edge cases or error conditions in non-Live Activity code
-- Direct UI component testing mixed with logic testing
 - No automation or CI/CD integration for testing
 - Need to extend testing approach to other app components using Live Activity patterns
+
+### Detailed Test Plans
+- [NotificationManager unit tests](./notification-manager-unit-tests.md)
+- [AppShortcutsProvider unit tests](./app-shortcuts-provider-unit-tests.md)
+- [Timer background task lifecycle tests](./timer-background-task-tests.md)
+- [Timer UI flow UI tests](./timer-ui-flow-ui-tests.md)
 
 ## Motivation and Benefits
 
@@ -39,7 +48,7 @@ Improving the testing strategy will:
 ### Phase 1: Unit Testing Framework
 
 1. **Expand Unit Test Coverage**
-   - Create unit tests for all manager classes (HealthKitManager, SoundManager)
+   - Add unit tests for remaining shared services ([NotificationManager](./notification-manager-unit-tests.md), [AppShortcutsProvider](./app-shortcuts-provider-unit-tests.md), [background task helpers](./timer-background-task-tests.md))
    - Add tests for model classes and utility functions
    - Implement tests for edge cases and error conditions
    - Apply Live Activity testing patterns to other components
@@ -54,7 +63,7 @@ Improving the testing strategy will:
 
 1. **Implement UI Tests**
    - Create dedicated UI test target
-   - Implement tests for critical user flows
+   - Implement tests for critical user flows ([Timer UI flow UI tests](./timer-ui-flow-ui-tests.md))
    - Test accessibility compliance
 
 2. **Extract Testable Components**
@@ -78,17 +87,18 @@ Improving the testing strategy will:
 
 ### Achieved
 - ✅ **Live Activity functionality**: 100% test coverage achieved
-- ✅ **Shared utility functions**: Fully tested with edge cases  
+- ✅ **Shared utility functions**: Fully tested with edge cases
 - ✅ **Preview consistency**: Automated validation implemented
 - ✅ **TDD guidance**: Integrated into project documentation
 - ✅ **Code duplication elimination**: Preview providers refactored with shared logic
 - ✅ **Testing infrastructure**: 53 test methods across 5 test classes established
 - ✅ **Build configuration**: Development team setup automated
+- ✅ **Core health and audio services**: `HealthKitManager` and `SoundManager` covered by focused unit tests
 
 ### Remaining Goals
 - Achieve 80%+ code coverage across the entire codebase
 - All critical user flows covered by UI tests
-- All core business logic has unit tests (HealthKitManager, SoundManager)
+- All core business logic has unit tests (NotificationManager, AppShortcutsProvider, background task helpers)
 - All edge cases and error conditions have test coverage
 - Tests run automatically on all pull requests
 
@@ -104,7 +114,7 @@ Improving the testing strategy will:
 ## Timeline
 
 - **Week 1**: Create unit tests for core models and utilities
-- **Week 2**: Implement tests for manager classes and services
+- **Week 2**: Implement tests for remaining shared services (NotificationManager, AppShortcutsProvider, background task helpers)
 - **Week 3**: Set up UI testing framework and implement critical flow tests
 - **Week 4**: Configure CI/CD integration and reporting
 - **Ongoing**: Maintain and expand test coverage with new features

--- a/specs/todo/tech-debt/timer-background-task-tests.md
+++ b/specs/todo/tech-debt/timer-background-task-tests.md
@@ -1,0 +1,47 @@
+# Spec: Timer Background Task Tests
+
+## Objective
+Cover the timer background task lifecycle so regressions in how `TimerViewModel` cooperates with `UIApplication` are caught before shipping.
+
+## Current Gaps
+- `TimerViewModel.start()` begins a background task but we have no verification that an identifier is stored or that the expiration handler resets state.
+- `TimerViewModel.reset()` attempts to end any active background task, yet we lack tests proving it always calls `endBackgroundTask` and clears the identifier.
+- Expiration handlers should end tasks even when `reset()` is never called (e.g., the system terminates background execution), but we currently have no automated coverage.
+- Because `TimerViewModel` touches `UIApplication.shared` directly, it is impossible to validate the behavior with a deterministic test double today.
+
+## Proposed Test Coverage
+### Start Lifecycle
+- When `start()` is invoked, `beginBackgroundTask` should be called once and the returned identifier stored on the view model.
+- The expiration handler passed to `beginBackgroundTask` should call `endBackgroundTask` and set the identifier back to `.invalid`.
+
+### Reset Lifecycle
+- If `backgroundTask` is active, `reset()` should call `endBackgroundTask` exactly once and reset the identifier to `.invalid`.
+- When no background task exists, `reset()` should skip additional calls (preventing redundant `endBackgroundTask` invocations).
+
+### Integration With Timer Cancellation
+- Triggering the expiration handler while the timer is running should leave the timer in a clean state (no leaked identifier, timer invalidated).
+
+## Implementation Plan
+1. **Abstract UIApplication Access**
+   - Introduce a `BackgroundTaskManaging` protocol exposing `beginBackgroundTask(withName:expirationHandler:)` and `endBackgroundTask(_:)` along with `isIdleTimerDisabled` mutation where needed.
+   - Provide a production wrapper backed by `UIApplication.shared` and inject it into `TimerViewModel` (defaulting to the live app).
+
+2. **Provide Test Doubles**
+   - Create a spy implementation recording begin/end invocations, capturing the expiration handler, and exposing the identifiers used.
+
+3. **Refactor TimerViewModel**
+   - Update the initializer to accept the new dependency so tests can inject the spy.
+   - Ensure resetting the timer also notifies the injected manager rather than `UIApplication.shared` directly.
+
+4. **Author Tests**
+   - Add `TimerBackgroundTaskTests` verifying each scenario above using the spy.
+   - Simulate the expiration handler by invoking the captured closure to ensure cleanup occurs without manual reset calls.
+
+## Dependencies & Tooling
+- `XCTest`
+- Newly introduced protocol + wrapper inside the production module
+
+## Acceptance Criteria
+- Tests fail if the timer stops ending background tasks or fails to clear identifiers when required.
+- `TimerViewModel` no longer references `UIApplication.shared` directly for background task management, enabling deterministic tests.
+- Expiration handler behavior is covered so a regression (e.g., forgetting to set identifier back to `.invalid`) is caught immediately.

--- a/specs/todo/tech-debt/timer-ui-flow-ui-tests.md
+++ b/specs/todo/tech-debt/timer-ui-flow-ui-tests.md
@@ -1,0 +1,60 @@
+# Spec: Timer UI Flow UI Tests
+
+## Objective
+Add UI automation that exercises the primary meditation timer flows so changes to SwiftUI views or wiring between `TimerStartView` and `TimerRunningView` are caught immediately.
+
+## Current Gaps
+- No XCUITests cover the start-to-finish timer journey, so regressions in sheet presentation or button wiring can ship unnoticed.
+- Duration preset buttons expose accessibility identifiers (e.g., `duration_5`) but nothing verifies they toggle or remain selected.
+- Cancel and complete actions are untested, so future refactors could stop dismissing the running timer or leave lingering state.
+- Launch-time setup (e.g., notification authorization requests) isn’t exercised under UI automation, risking prompts or flakiness without guardrails.
+
+## Proposed Test Coverage
+1. **Launch Smoke Test**
+   - Launch the app with `-DISABLE_SYSTEM_INTEGRATIONS` to bypass HealthKit/notification work.
+   - Assert the start screen renders the mantra emoji, settings button, and “Start session” control.
+
+2. **Start Session Flow**
+   - Tap “Start session” and verify the timer sheet appears by asserting the existence of the cancel/complete buttons and the timer label.
+   - Confirm that `UIApplication.shared.isIdleTimerDisabled` toggling is observable via the background task spy when available (or future instrumentation).
+
+3. **Duration Preset Selection**
+   - Tap a preset button (e.g., “5”) and verify its accessibility identifier flips to `selected_duration_5`.
+   - Tap the same button again to ensure it toggles off and pending notifications are removed (observed via NotificationManager spy instrumentation once available).
+
+4. **Cancel Flow**
+   - From the running view, tap “Cancel” and assert the sheet dismisses back to the start screen.
+   - Validate that the timer sheet disappears within a reasonable timeout to guard against regressions in dismissal logic.
+
+5. **Complete Flow (Smoke)**
+   - Start a session, tap “Complete”, and confirm the start screen reappears without crashing.
+   - Use launch arguments to disable system integrations so HealthKit/notification side effects don’t interfere with the UI test run.
+
+6. **Settings Sheet**
+   - From the start screen, tap the gear button and ensure the settings sheet appears, then dismiss it to verify bidirectional sheet control.
+
+## Implementation Plan
+1. **Create XCUITest Target Coverage File**
+   - Add `TimerUITests` XCTestCase with helper methods for launching the app using the shared `UITestApp` wrapper (if available) or `XCUIApplication` directly.
+
+2. **Adopt Launch Arguments**
+   - Append `-DISABLE_SYSTEM_INTEGRATIONS` (already honored by the views) plus any stubs needed for Live Activity/HealthKit to keep the run deterministic.
+
+3. **Author Individual Tests**
+   - One test per flow outlined above to keep failures focused.
+   - Use accessibility identifiers already defined in SwiftUI (`duration_*`, `selected_duration_*`) for reliable element lookup.
+
+4. **Add Helpers for Sheet Detection**
+   - Implement polling helpers that wait for the timer sheet to appear/disappear via `.exists` checks to avoid flakiness.
+
+5. **Future Enhancements**
+   - Once NotificationManager and BackgroundTask tests introduce injectable spies, surface those toggles to UI tests (via launch environment) so UI automation can assert side effects without hitting real APIs.
+
+## Dependencies & Tooling
+- `XCTest` UI testing bundle
+- Launch arguments wiring inside the main target (already partially implemented)
+
+## Acceptance Criteria
+- UI tests fail if the timer no longer opens, cancels, or completes correctly.
+- Duration preset buttons must change accessibility state in UI automation, preventing accidental regressions in selection logic.
+- Smoke coverage exists for the settings sheet and main navigation, ensuring primary mindfulness flows are under automation.


### PR DESCRIPTION
## Summary
- add focused specs for NotificationManager, AppShortcutsProvider, timer background task handling, and timer UI automation gaps
- update the overarching testing strategy to reference the new specs and emphasize remaining coverage priorities

## Testing
- `fastlane format_code` *(fails: command not found: fastlane)*
- `fastlane lint` *(fails: command not found: fastlane)*

------
https://chatgpt.com/codex/tasks/task_e_68c84c1cc0508328b4f9bd54fe21bfbb