### PR TITLE
Promote widget duration backlog task to Now

### DIFF
--- a/backlog/tasks/task-2 - Expand-widget-size-options.md
+++ b/backlog/tasks/task-2 - Expand-widget-size-options.md
@@ -1,0 +1,21 @@
+---
+id: task-2
+title: Expand widget size options
+status: Next
+assignee: []
+created_date: '2025-09-17 13:00'
+labels:
+  - ui
+dependencies: []
+---
+
+## Description
+
+Audit the current widget extension layout and determine which additional iOS widget families we can support without compromising readability. Partner with design to propose layouts for the new sizes and document any additional assets or localization needs.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Design review signed off for every newly supported widget family.
+- [ ] #2 Widget renders correctly on simulator for each target size with no clipped text or layout warnings.
+- [ ] #3 Document updated with size availability matrix and any follow-up engineering work.
+<!-- AC:END -->

--- a/backlog/tasks/task-3 - Configure-widget-quick-start-durations.md
+++ b/backlog/tasks/task-3 - Configure-widget-quick-start-durations.md
@@ -1,0 +1,22 @@
+---
+id: task-3
+title: Configure widget quick-start durations
+status: Now
+assignee: []
+created_date: '2025-09-17 13:00'
+updated_date: '2025-09-17 13:36'
+labels:
+  - ui
+dependencies: []
+---
+
+## Description
+
+Design a user-friendly way to choose which session lengths appear on the widget quick-start buttons. Explore whether this lives in app settings or via in-widget configuration and document trade-offs. Ensure the chosen approach keeps the list manageable and ordered for fast selection.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Configuration UI allows selecting at least 3 preferred durations from a broader list.
+- [ ] #2 Quick-start buttons show the chosen times sorted from shortest to longest and persist across launches.
+- [ ] #3 Edge cases covered for when users select fewer or more durations than the widget can display.
+<!-- AC:END -->

--- a/backlog/tasks/task-4 - Add-app-icon-long-press-quick-session.md
+++ b/backlog/tasks/task-4 - Add-app-icon-long-press-quick-session.md
@@ -1,0 +1,21 @@
+---
+id: task-4
+title: Add app icon long-press quick session
+status: Next
+assignee: []
+created_date: '2025-09-17 13:00'
+labels:
+  - ui
+dependencies: []
+---
+
+## Description
+
+Define and implement a Home Screen quick action so users can start a meditation session directly from the app icon long-press menu. Align on which duration should launch, how it interacts with existing quick actions, and what feedback the user gets when the app opens.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 At least one long-press quick action starts a session without additional taps once the app opens.
+- [ ] #2 Behavior documented for when a session is already running or HealthKit permissions are missing.
+- [ ] #3 QA notes cover supported devices/iOS versions and any limitations of Home Screen quick actions.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- update backlog task-3 status to Now to prioritize configuring widget quick-start durations

## Testing
- not run (backlog metadata update)


------
https://chatgpt.com/codex/tasks/task_e_68cab0c6007883288deb0aa4b3cc38de