### PR TITLE
fix(widget): refresh live activity controls

### DIFF
--- a/LittleMoments/Features/LiveActivity/Models/LiveActivityManager.swift
+++ b/LittleMoments/Features/LiveActivity/Models/LiveActivityManager.swift
@@ -47,7 +47,10 @@ final class LiveActivityManager {
     do {
       print("🔄 Requesting Live Activity from system")
       // Request new Live Activity from the system
-      let activityContent = ActivityContent(state: initialState, staleDate: nil)
+      let activityContent = ActivityContent(
+        state: initialState,
+        staleDate: Date().addingTimeInterval(1)
+      )
       activity = try Activity.request(
         attributes: attributes,
         content: activityContent,
@@ -94,7 +97,10 @@ final class LiveActivityManager {
     )
 
     // Update the Live Activity asynchronously
-    let updatedContent = ActivityContent(state: updatedState, staleDate: nil)
+    let updatedContent = ActivityContent(
+      state: updatedState,
+      staleDate: Date().addingTimeInterval(1)
+    )
     await activity?.update(updatedContent)
 
     if isCompleted {

--- a/LittleMoments/Features/LiveActivity/Views/MeditationLiveActivityView.swift
+++ b/LittleMoments/Features/LiveActivity/Views/MeditationLiveActivityView.swift
@@ -35,19 +35,19 @@ struct MeditationLiveActivityView: View {
 
         // Replace single button with two buttons
         HStack(spacing: 12) {
-          Button("Finish") {
-            // This will be handled by deeplink
-          }
-          .buttonStyle(.bordered)
-          .tint(.green)
-          .widgetURL(URL(string: "littlemoments://finishSession"))
-
           Button("Cancel") {
             // This will be handled by deeplink
           }
           .buttonStyle(.bordered)
           .tint(.red)
           .widgetURL(URL(string: "littlemoments://cancelSession"))
+
+          Button("Finish") {
+            // This will be handled by deeplink
+          }
+          .buttonStyle(.bordered)
+          .tint(.green)
+          .widgetURL(URL(string: "littlemoments://finishSession"))
         }
       }
       .padding()

--- a/LittleMoments/WidgetExtension/LiveActivityManager.swift
+++ b/LittleMoments/WidgetExtension/LiveActivityManager.swift
@@ -43,7 +43,10 @@ final class LiveActivityManager {
     do {
       print("🔄 Widget: Requesting Live Activity from system")
       // Request new Live Activity from the system
-      let activityContent = ActivityContent(state: initialState, staleDate: nil)
+      let activityContent = ActivityContent(
+        state: initialState,
+        staleDate: Date().addingTimeInterval(1)
+      )
       activity = try Activity.request(
         attributes: attributes,
         content: activityContent,
@@ -86,7 +89,10 @@ final class LiveActivityManager {
     )
 
     // Update the Live Activity asynchronously
-    let updatedContent = ActivityContent(state: updatedState, staleDate: nil)
+    let updatedContent = ActivityContent(
+      state: updatedState,
+      staleDate: Date().addingTimeInterval(1)
+    )
     await activity?.update(updatedContent)
 
     if isCompleted {

--- a/LittleMoments/WidgetExtension/MeditationLiveActivityView.swift
+++ b/LittleMoments/WidgetExtension/MeditationLiveActivityView.swift
@@ -36,17 +36,6 @@ struct MeditationLiveActivityView: View {
 
         // Use links instead of buttons for deep linking
         HStack(spacing: 12) {
-          if let url = URL(string: "littlemoments://finishSession") {
-            Link(destination: url) {
-              Text("Finish")
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
-                .background(Color.green.opacity(0.2))
-                .cornerRadius(8)
-                .foregroundColor(.green)
-            }
-          }
-
           if let url = URL(string: "littlemoments://cancelSession") {
             Link(destination: url) {
               Text("Cancel")
@@ -55,6 +44,17 @@ struct MeditationLiveActivityView: View {
                 .background(Color.red.opacity(0.2))
                 .cornerRadius(8)
                 .foregroundColor(.red)
+            }
+          }
+
+          if let url = URL(string: "littlemoments://finishSession") {
+            Link(destination: url) {
+              Text("Finish")
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 6)
+                .background(Color.green.opacity(0.2))
+                .cornerRadius(8)
+                .foregroundColor(.green)
             }
           }
         }

--- a/LittleMoments/WidgetExtension/WidgetBundle.swift
+++ b/LittleMoments/WidgetExtension/WidgetBundle.swift
@@ -47,18 +47,6 @@ struct MeditationLiveActivityWidget: Widget {
 
         DynamicIslandExpandedRegion(.bottom) {
           HStack(spacing: 12) {
-            // Complete session link
-            if let url = URL(string: "littlemoments://finishSession") {
-              Link(destination: url) {
-                Label("Complete", systemImage: "checkmark.circle.fill")
-                  .frame(maxWidth: .infinity)
-                  .padding(.vertical, 6)
-                  .background(Color.green.opacity(0.2))
-                  .cornerRadius(8)
-                  .foregroundColor(.green)
-              }
-            }
-
             // Cancel session link
             if let url = URL(string: "littlemoments://cancelSession") {
               Link(destination: url) {
@@ -68,6 +56,18 @@ struct MeditationLiveActivityWidget: Widget {
                   .background(Color.red.opacity(0.2))
                   .cornerRadius(8)
                   .foregroundColor(.red)
+              }
+            }
+
+            // Complete session link
+            if let url = URL(string: "littlemoments://finishSession") {
+              Link(destination: url) {
+                Label("Complete", systemImage: "checkmark.circle.fill")
+                  .frame(maxWidth: .infinity)
+                  .padding(.vertical, 6)
+                  .background(Color.green.opacity(0.2))
+                  .cornerRadius(8)
+                  .foregroundColor(.green)
               }
             }
           }
@@ -130,17 +130,6 @@ struct MeditationLiveActivityWidget: Widget {
 
           // Use links instead of buttons for deep linking
           HStack(spacing: 12) {
-            if let url = URL(string: "littlemoments://finishSession") {
-              Link(destination: url) {
-                Text("Finish")
-                  .frame(maxWidth: .infinity)
-                  .padding(.vertical, 6)
-                  .background(Color.green.opacity(0.2))
-                  .cornerRadius(8)
-                  .foregroundColor(.green)
-              }
-            }
-
             if let url = URL(string: "littlemoments://cancelSession") {
               Link(destination: url) {
                 Text("Cancel")
@@ -149,6 +138,17 @@ struct MeditationLiveActivityWidget: Widget {
                   .background(Color.red.opacity(0.2))
                   .cornerRadius(8)
                   .foregroundColor(.red)
+              }
+            }
+
+            if let url = URL(string: "littlemoments://finishSession") {
+              Link(destination: url) {
+                Text("Finish")
+                  .frame(maxWidth: .infinity)
+                  .padding(.vertical, 6)
+                  .background(Color.green.opacity(0.2))
+                  .cornerRadius(8)
+                  .foregroundColor(.green)
               }
             }
           }


### PR DESCRIPTION
## Summary
- swap the cancel and finish actions in the live activity view so cancel appears on the left on the Lock Screen, previews, and Dynamic Island
- request Live Activity updates as stale after one second to prompt the system to refresh the timer display every second even when seconds are hidden

## Testing
- not run (bundle install blocked by 403 Forbidden when fetching gems)


------
https://chatgpt.com/codex/tasks/task_e_68cdee1900e0832894099f1793aff511