### PR TITLE
Add devcontainer with Backlog.md tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "LittleMoments • Swift + Backlog.md",
+  "image": "swift:6.0-jammy",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/node:1": { "version": "lts" }
+  },
+  "postCreateCommand": "npm i -g backlog.md && backlog --version",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "swiftlang.swift-vscode"
+      ]
+    }
+  },
+  "portsAttributes": {
+    "8080": {
+      "label": "Backlog.md browser",
+      "onAutoForward": "openBrowser"
+    }
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Backlog: Board (TUI)",
+      "type": "shell",
+      "command": "backlog board view",
+      "problemMatcher": []
+    },
+    {
+      "label": "Backlog: Browser (port 8080)",
+      "type": "shell",
+      "command": "backlog browser --port 8080 --no-open",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Swift-based devcontainer that preinstalls Backlog.md and forwards port 8080
- configure VS Code to include the Swift extension when opened in the container
- add VS Code tasks for launching the Backlog.md TUI board and browser server

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4150fe9883289f459dafe00aace6