### PR TITLE
Add custom meditation duration UI and shared duration model; unify timer target handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gem "fastlane"
 gem "xcpretty"
 gem "logger"
 gem "abbrev"
+
+gem "ostruct", "~> 0.6.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     nkf (0.2.0)
     optparse (0.6.0)
     os (1.1.4)
+    ostruct (0.6.3)
     plist (3.7.2)
     public_suffix (6.0.1)
     rake (13.2.1)
@@ -224,6 +225,7 @@ DEPENDENCIES
   abbrev
   fastlane
   logger
+  ostruct (~> 0.6.3)
   xcpretty
 
 BUNDLED WITH

--- a/LittleMoments/App/iOS/Little_MomentsApp.swift
+++ b/LittleMoments/App/iOS/Little_MomentsApp.swift
@@ -191,7 +191,7 @@ struct LittleMomentsApp: App {
       {
         if let durationString = items.first(where: { $0.name.lowercased() == "duration" })?.value {
           let seconds = Self.parseDurationToSeconds(durationString)
-          if let seconds {
+          if let seconds, seconds > 0 {
             print("📲 Will start with preset duration: \(seconds) sec")
             AppState.shared.pendingStartDurationSeconds = seconds
           }

--- a/LittleMoments/Core/AppShortcutsProvider.swift
+++ b/LittleMoments/Core/AppShortcutsProvider.swift
@@ -13,6 +13,7 @@ struct LittleMomentsShortcuts: AppShortcutsProvider {
         "Begin meditation in \(.applicationName)",
         "Meditate in \(.applicationName)",
         "Start an untimed meditation in \(.applicationName)",
+        "Start a timed meditation in \(.applicationName)",
       ],
       shortTitle: "Start Meditation",
       systemImageName: "play.circle.fill"

--- a/LittleMoments/Core/Audio/MeditationDuration.swift
+++ b/LittleMoments/Core/Audio/MeditationDuration.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct MeditationDuration: Equatable {
+  static let minimumMinutes = 1
+  static let sliderMinimumMinutes = 1
+  static let sliderMaximumMinutes = 120
+
+  enum ValidationError: LocalizedError, Equatable {
+    case empty
+    case notWholeMinutes
+    case belowMinimum
+
+    var errorDescription: String? {
+      switch self {
+      case .empty:
+        return "Add a duration before applying."
+      case .notWholeMinutes:
+        return "Enter whole minutes."
+      case .belowMinimum:
+        return "Enter at least 1 minute."
+      }
+    }
+  }
+
+  let minutes: Int
+
+  static let uncheckedMinimum = MeditationDuration(uncheckedMinutes: minimumMinutes)
+
+  private init(uncheckedMinutes minutes: Int) {
+    self.minutes = minutes
+  }
+
+  init(minutes: Int) throws {
+    guard minutes >= Self.minimumMinutes else { throw ValidationError.belowMinimum }
+    self.minutes = minutes
+  }
+
+  var seconds: Int { minutes * 60 }
+
+  var shortLabel: String {
+    if minutes < 60 {
+      return "\(minutes) min"
+    }
+
+    let hours = minutes / 60
+    let remainingMinutes = minutes % 60
+    if remainingMinutes == 0 {
+      return "\(hours) hr"
+    }
+    return "\(hours) hr \(remainingMinutes) min"
+  }
+
+  var accessibilityLabel: String {
+    if minutes < 60 {
+      return minutes == 1 ? "1 minute" : "\(minutes) minutes"
+    }
+
+    let hours = minutes / 60
+    let remainingMinutes = minutes % 60
+    let hourText = hours == 1 ? "1 hour" : "\(hours) hours"
+    guard remainingMinutes > 0 else { return hourText }
+
+    let minuteText = remainingMinutes == 1 ? "1 minute" : "\(remainingMinutes) minutes"
+    return "\(hourText) \(minuteText)"
+  }
+
+  var timerOptionName: String {
+    if minutes < 60 {
+      return "\(minutes)"
+    }
+    return shortLabel
+  }
+
+  static func parseMinutes(_ raw: String) -> Result<MeditationDuration, ValidationError> {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return .failure(.empty) }
+    guard trimmed.allSatisfy(\.isNumber), let minutes = Int(trimmed) else {
+      return .failure(.notWholeMinutes)
+    }
+
+    do {
+      return .success(try MeditationDuration(minutes: minutes))
+    } catch let error as ValidationError {
+      return .failure(error)
+    } catch {
+      return .failure(.notWholeMinutes)
+    }
+  }
+
+  static func clampedSliderMinutes(_ value: Double) -> Int {
+    let rounded = Int(value.rounded())
+    return min(max(rounded, sliderMinimumMinutes), sliderMaximumMinutes)
+  }
+}

--- a/LittleMoments/Core/Audio/ScheduledBellAlert.swift
+++ b/LittleMoments/Core/Audio/ScheduledBellAlert.swift
@@ -17,6 +17,15 @@ class OneTimeScheduledBellAlert: ScheduledAlert {
 
   let targetTimeInSec: CGFloat
   let name: String
+  var notificationDurationDescription: String {
+    if Int(targetTimeInSec) % 60 == 0,
+      let duration = try? MeditationDuration(minutes: Int(targetTimeInSec) / 60)
+    {
+      return duration.shortLabel
+    }
+    return name
+  }
+
   var hasTriggered: Bool = false
   let hasTarget: Bool = true
 
@@ -52,8 +61,8 @@ class OneTimeScheduledBellAlert: ScheduledAlert {
   }
 
   func doTrigger(secondsElapsed: CGFloat) {
-    let MAX_DELAY: CGFloat = 5.0
-    if secondsElapsed - targetTimeInSec > MAX_DELAY {
+    let maxDelay: CGFloat = 5.0
+    if secondsElapsed - targetTimeInSec > maxDelay {
       print("Skipping sound due to delay")
       return
     }

--- a/LittleMoments/Features/Meditation/Models/MeditationSessionIntent.swift
+++ b/LittleMoments/Features/Meditation/Models/MeditationSessionIntent.swift
@@ -27,7 +27,8 @@ public struct MeditationSessionIntent: AppIntent {
   @MainActor
   public func perform() async throws -> some IntentResult {
     if let durationMinutes {
-      AppState.shared.pendingStartDurationSeconds = durationMinutes * 60
+      let duration = try MeditationDuration(minutes: durationMinutes)
+      AppState.shared.pendingStartDurationSeconds = duration.seconds
     }
     AppState.shared.showTimerRunningView = true
     return .result()

--- a/LittleMoments/Features/Timer/Models/TimerViewModel.swift
+++ b/LittleMoments/Features/Timer/Models/TimerViewModel.swift
@@ -9,6 +9,7 @@ import ActivityKit
 import Foundation
 import SwiftUI
 import UIKit
+import UserNotifications
 
 @MainActor
 class TimerViewModel: ObservableObject {
@@ -40,13 +41,8 @@ class TimerViewModel: ObservableObject {
 
   // Options for and actually scheduled "end time" alert
   @Published var scheduledAlertOptions: [OneTimeScheduledBellAlert]
-  private var temporaryAlertOption: OneTimeScheduledBellAlert?
-  private var removedAlertOption: OneTimeScheduledBellAlert?
   @Published var scheduledAlert: OneTimeScheduledBellAlert? {
     didSet {
-      if let temp = temporaryAlertOption, scheduledAlert != temp {
-        removeTemporaryAlertOption()
-      }
       // Update Live Activity when timer duration changes
       if JustNowSettings.shared.enableLiveActivities {
         let targetSeconds: Double? = scheduledAlert.map { Double($0.targetTimeInSec) }
@@ -92,52 +88,75 @@ class TimerViewModel: ObservableObject {
     }
   }
 
+  var hasCustomDurationTarget: Bool {
+    guard let scheduledAlert else { return false }
+    return !scheduledAlertOptions.contains(scheduledAlert)
+  }
+
+  var customDurationLabel: String? {
+    guard hasCustomDurationTarget, let scheduledAlert else { return nil }
+    return scheduledAlert.name
+  }
+
   func applyPresetDuration(_ seconds: Int) {
-    // Check if this duration matches an existing option (excluding any temporary option)
-    let existingOption = scheduledAlertOptions.first(where: {
-      Int($0.targetTimeInSec) == seconds && $0 != temporaryAlertOption
-    })
+    setDurationTarget(seconds: seconds, schedulesNotification: false)
+  }
 
-    if existingOption != nil {
-      // Remove any existing temporary option before selecting the existing one
-      removeTemporaryAlertOption()
-      // Now find and select the existing option
-      if let match = scheduledAlertOptions.first(where: { Int($0.targetTimeInSec) == seconds }) {
-        scheduledAlert = match
-      }
+  func setDurationTarget(minutes: Int, schedulesNotification: Bool = true) {
+    guard let duration = try? MeditationDuration(minutes: minutes) else { return }
+    setDurationTarget(seconds: duration.seconds, schedulesNotification: schedulesNotification)
+  }
+
+  func setDurationTarget(seconds: Int, schedulesNotification: Bool = true) {
+    guard seconds > 0 else { return }
+
+    if let match = scheduledAlertOptions.first(where: { Int($0.targetTimeInSec) == seconds }) {
+      scheduledAlert = match
     } else {
-      // Create a temporary option for this duration
-      addTemporaryAlertOptionIfNeeded(seconds)
-      if let match = scheduledAlertOptions.first(where: { Int($0.targetTimeInSec) == seconds }) {
-        scheduledAlert = match
+      let minutes = seconds / 60
+      let label: String
+      if seconds % 60 == 0, let duration = try? MeditationDuration(minutes: minutes) {
+        label = duration.timerOptionName
+      } else {
+        label = "\(seconds)s"
       }
+      scheduledAlert = OneTimeScheduledBellAlert(targetTimeInSec: seconds, name: label)
+    }
+
+    if schedulesNotification, let scheduledAlert {
+      scheduleTimerNotification(for: scheduledAlert)
     }
   }
 
-  private func addTemporaryAlertOptionIfNeeded(_ seconds: Int) {
-    let label = seconds % 60 == 0 ? "\(seconds / 60)" : "\(seconds)s"
-
-    // Remove any existing temporary option first
-    removeTemporaryAlertOption()
-
-    // Create and add the new temporary option
-    let option = OneTimeScheduledBellAlert(targetTimeInSec: seconds, name: label)
-    scheduledAlertOptions.insert(option, at: 0)
-    if scheduledAlertOptions.count > 8 {
-      removedAlertOption = scheduledAlertOptions.removeLast()
-    }
-    temporaryAlertOption = option
+  func clearDurationTarget() {
+    scheduledAlert = nil
+    UNUserNotificationCenter.current().removePendingNotificationRequests(
+      withIdentifiers: ["timerNotification"]
+    )
   }
 
-  private func removeTemporaryAlertOption() {
-    if let temp = temporaryAlertOption, let index = scheduledAlertOptions.firstIndex(of: temp) {
-      scheduledAlertOptions.remove(at: index)
+  private func scheduleTimerNotification(for alert: OneTimeScheduledBellAlert) {
+    if ProcessInfo.processInfo.arguments.contains("-DISABLE_SYSTEM_INTEGRATIONS") {
+      return
     }
-    if let removed = removedAlertOption {
-      scheduledAlertOptions.append(removed)
-      removedAlertOption = nil
+
+    let remainingSeconds = TimeInterval(alert.targetTimeInSec - secondsElapsed)
+    guard remainingSeconds > 0 else {
+      UNUserNotificationCenter.current().removePendingNotificationRequests(
+        withIdentifiers: ["timerNotification"]
+      )
+      return
     }
-    temporaryAlertOption = nil
+
+    Task {
+      try? await NotificationManager.shared.scheduleTimerNotification(
+        identifier: "timerNotification",
+        title: "Timer Complete",
+        body: "Your \(alert.notificationDurationDescription) timer has finished",
+        soundName: "42095__fauxpress__bell-meditation.aif",
+        timeInterval: remainingSeconds
+      )
+    }
   }
 
   func start() {
@@ -266,7 +285,6 @@ class TimerViewModel: ObservableObject {
   init() {
     // Initialize scheduledAlertOptions with default values
     self.scheduledAlertOptions = [
-      OneTimeScheduledBellAlert(targetTimeInMin: 1),
       OneTimeScheduledBellAlert(targetTimeInMin: 5),
       OneTimeScheduledBellAlert(targetTimeInMin: 10),
       OneTimeScheduledBellAlert(targetTimeInMin: 15),
@@ -277,7 +295,7 @@ class TimerViewModel: ObservableObject {
     ]
 
     #if targetEnvironment(simulator)
-      // Add a short 5-second option for testing in simulator
+      // Add a short 5-second option for testing in simulator while keeping seven preset slots.
       scheduledAlertOptions[0] = OneTimeScheduledBellAlert(targetTimeInSec: 5, name: "5 sec")
     #endif
 
@@ -382,7 +400,6 @@ class TimerViewModel: ObservableObject {
     startDate = nil
 
     scheduledAlert = nil
-    removeTemporaryAlertOption()
 
     // Reset the cancelled flag and timestamp for future sessions
     wasCancelled = false

--- a/LittleMoments/Features/Timer/Models/TimerViewModel.swift
+++ b/LittleMoments/Features/Timer/Models/TimerViewModel.swift
@@ -98,6 +98,14 @@ class TimerViewModel: ObservableObject {
     return scheduledAlert.name
   }
 
+  var customDurationChipLabel: String? {
+    guard hasCustomDurationTarget, let scheduledAlert else { return nil }
+
+    let seconds = Int(scheduledAlert.targetTimeInSec)
+    guard seconds.isMultiple(of: 60) else { return "\(seconds)s" }
+    return "\(seconds / 60)"
+  }
+
   func applyPresetDuration(_ seconds: Int) {
     setDurationTarget(seconds: seconds, schedulesNotification: false)
   }

--- a/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
+++ b/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
@@ -8,12 +8,7 @@ enum CustomDurationSheetMode: Equatable {
   var title: String { "Custom duration" }
 
   var subtitle: String {
-    switch self {
-    case .start:
-      return "Choose when the bell should end this session."
-    case .running:
-      return "Your timer keeps running while you adjust the bell."
-    }
+    "Set when the bell should sound."
   }
 
   var compactApplyTitle: String {
@@ -45,6 +40,7 @@ struct CustomDurationSheet: View {
   @State private var minutesText: String
   @State private var validationMessage: String?
   @State private var lastHapticMinute: Int
+  @FocusState private var minutesFieldIsFocused: Bool
 
   init(
     mode: CustomDurationSheetMode,
@@ -61,17 +57,24 @@ struct CustomDurationSheet: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 18) {
+    VStack(alignment: .leading, spacing: 20) {
       header
-      durationEntryAndApplyRow
+      durationEditorSection
       sliderSection
-      footerActions
     }
     .padding(.horizontal, 24)
     .padding(.top, 20)
     .padding(.bottom, 18)
     .frame(maxWidth: .infinity, alignment: .topLeading)
     .background(backgroundSurface)
+    .toolbar {
+      ToolbarItemGroup(placement: .keyboard) {
+        Spacer()
+        Button("Done") {
+          dismissKeyboard()
+        }
+      }
+    }
     .accessibilityIdentifier("custom_duration_sheet")
   }
 
@@ -87,26 +90,9 @@ struct CustomDurationSheet: View {
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
-  private var durationEntryAndApplyRow: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      HStack(alignment: .center, spacing: 12) {
-        durationEntryCard
-
-        Button {
-          applyDuration()
-        } label: {
-          VStack(spacing: 3) {
-            Image(systemName: "checkmark")
-              .font(.system(size: 20, weight: .bold))
-            Text(mode.compactApplyTitle)
-              .font(.caption.weight(.semibold))
-          }
-        }
-        .accessibilityIdentifier("custom_duration_apply_button")
-        .accessibilityLabel(mode.applyTitle(for: currentDuration))
-        .liquidGlassIconButtonStyle(variant: .prominent, role: .success, diameter: 68)
-      }
-
+  private var durationEditorSection: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      durationControlRow
       Text(validationMessage ?? "Tap the value to type, or use the slider for 1 min–2 hr.")
         .font(.footnote)
         .foregroundStyle(validationMessage == nil ? Color.secondary : Color.red)
@@ -114,10 +100,34 @@ struct CustomDurationSheet: View {
     }
   }
 
-  private var durationEntryCard: some View {
+  private var durationControlRow: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(alignment: .center, spacing: 10) {
+        durationEntryField
+        actionButtons
+      }
+
+      VStack(alignment: .leading, spacing: 12) {
+        durationEntryField
+        actionButtons
+          .frame(maxWidth: .infinity, alignment: .trailing)
+      }
+    }
+  }
+
+  private var durationEntryField: some View {
     HStack(alignment: .firstTextBaseline, spacing: 8) {
-      SelectAllMinutesTextField(text: $minutesText)
-        .frame(minHeight: 48)
+      TextField("", text: $minutesText)
+        .keyboardType(.numberPad)
+        .textInputAutocapitalization(.never)
+        .disableAutocorrection(true)
+        .multilineTextAlignment(.trailing)
+        .font(.system(size: 34, weight: .bold, design: .default))
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .focused($minutesFieldIsFocused)
+        .frame(maxWidth: .infinity, minHeight: 44, maxHeight: 44, alignment: .trailing)
+        .accessibilityIdentifier("custom_duration_minutes_field")
         .accessibilityHint("Enter a duration in minutes; values over 2 hours are allowed.")
         .onChange(of: minutesText) { _, newValue in
           updateDraftMinutes(from: newValue)
@@ -127,10 +137,13 @@ struct CustomDurationSheet: View {
         .font(.headline.weight(.semibold))
         .foregroundStyle(.secondary)
     }
-    .padding(.vertical, 16)
     .padding(.horizontal, 18)
-    .frame(maxWidth: .infinity, minHeight: 72)
+    .frame(minWidth: 132, maxWidth: .infinity)
+    .frame(height: 72)
     .contentShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    .onTapGesture {
+      minutesFieldIsFocused = true
+    }
     .background(
       RoundedRectangle(cornerRadius: 24, style: .continuous)
         .fill(
@@ -149,6 +162,29 @@ struct CustomDurationSheet: View {
         )
     )
     .accessibilityLabel(currentDuration.accessibilityLabel)
+  }
+
+  private var actionButtons: some View {
+    HStack(spacing: 10) {
+      Button {
+        onCancel()
+      } label: {
+        Text("Cancel")
+      }
+      .accessibilityIdentifier("custom_duration_cancel_button")
+      .liquidGlassButtonStyle(.subtle, role: .neutral, controlHeight: 72)
+      .frame(width: 92)
+
+      Button {
+        applyDuration()
+      } label: {
+        Text(mode.compactApplyTitle)
+      }
+      .accessibilityIdentifier("custom_duration_apply_button")
+      .accessibilityLabel(mode.applyTitle(for: currentDuration))
+      .liquidGlassButtonStyle(.prominent, role: .success, controlHeight: 72)
+      .frame(width: 78)
+    }
   }
 
   private var sliderSection: some View {
@@ -171,17 +207,6 @@ struct CustomDurationSheet: View {
       .font(.caption)
       .foregroundStyle(.secondary)
     }
-  }
-
-  private var footerActions: some View {
-    Button {
-      onCancel()
-    } label: {
-      Text("Cancel")
-        .frame(maxWidth: .infinity)
-    }
-    .accessibilityIdentifier("custom_duration_cancel_button")
-    .liquidGlassButtonStyle(.subtle, role: .neutral, controlHeight: 44)
   }
 
   private var backgroundSurface: some View {
@@ -255,12 +280,7 @@ struct CustomDurationSheet: View {
   }
 
   private func dismissKeyboard() {
-    UIApplication.shared.sendAction(
-      #selector(UIResponder.resignFirstResponder),
-      to: nil,
-      from: nil,
-      for: nil
-    )
+    minutesFieldIsFocused = false
   }
 
   private func provideSliderFeedbackIfNeeded(for minutes: Int) {
@@ -273,81 +293,6 @@ struct CustomDurationSheet: View {
     guard shouldProvideFeedback else { return }
 
     UIImpactFeedbackGenerator(style: .light).impactOccurred()
-  }
-}
-
-private struct SelectAllMinutesTextField: UIViewRepresentable {
-  @Binding var text: String
-
-  func makeUIView(context: Context) -> UITextField {
-    let textField = UITextField()
-    textField.delegate = context.coordinator
-    textField.keyboardType = .numberPad
-    textField.textAlignment = .right
-    textField.font = UIFont.systemFont(ofSize: 34, weight: .bold)
-    textField.adjustsFontForContentSizeCategory = true
-    textField.minimumFontSize = 24
-    textField.adjustsFontSizeToFitWidth = true
-    textField.accessibilityIdentifier = "custom_duration_minutes_field"
-    textField.addTarget(
-      context.coordinator,
-      action: #selector(Coordinator.textDidChange(_:)),
-      for: .editingChanged
-    )
-    textField.inputAccessoryView = context.coordinator.makeToolbar()
-    return textField
-  }
-
-  func updateUIView(_ textField: UITextField, context: Context) {
-    if textField.text != text {
-      textField.text = text
-    }
-  }
-
-  func makeCoordinator() -> Coordinator {
-    Coordinator(text: $text)
-  }
-
-  final class Coordinator: NSObject, UITextFieldDelegate {
-    @Binding private var text: String
-
-    init(text: Binding<String>) {
-      _text = text
-    }
-
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-      DispatchQueue.main.async {
-        textField.selectAll(nil)
-      }
-    }
-
-    @objc func textDidChange(_ textField: UITextField) {
-      text = textField.text ?? ""
-    }
-
-    @objc func doneTapped() {
-      UIApplication.shared.sendAction(
-        #selector(UIResponder.resignFirstResponder),
-        to: nil,
-        from: nil,
-        for: nil
-      )
-    }
-
-    func makeToolbar() -> UIToolbar {
-      let toolbar = UIToolbar()
-      toolbar.items = [
-        UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-        UIBarButtonItem(
-          title: "Done",
-          style: .done,
-          target: self,
-          action: #selector(doneTapped)
-        ),
-      ]
-      toolbar.sizeToFit()
-      return toolbar
-    }
   }
 }
 

--- a/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
+++ b/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
@@ -11,7 +11,16 @@ enum CustomDurationSheetMode: Equatable {
     case .start:
       return "Choose when the bell should end this session."
     case .running:
-      return "Choose when the bell should end this session. Your timer keeps running."
+      return "Your timer keeps running while you adjust the bell."
+    }
+  }
+
+  var compactApplyTitle: String {
+    switch self {
+    case .start:
+      return "Start"
+    case .running:
+      return "Set"
     }
   }
 
@@ -52,18 +61,16 @@ struct CustomDurationSheet: View {
   }
 
   var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 28) {
-        header
-        durationReadout
-        sliderSection
-        textInputSection
-        actions
-      }
-      .padding(.horizontal, 24)
-      .padding(.top, 28)
-      .padding(.bottom, 32)
+    VStack(alignment: .leading, spacing: 18) {
+      header
+      durationEntryAndApplyRow
+      sliderSection
+      footerActions
     }
+    .padding(.horizontal, 24)
+    .padding(.top, 20)
+    .padding(.bottom, 18)
+    .frame(maxWidth: .infinity, alignment: .topLeading)
     .background(backgroundSurface)
     .accessibilityIdentifier("custom_duration_sheet")
     .toolbar {
@@ -75,51 +82,89 @@ struct CustomDurationSheet: View {
   }
 
   private var header: some View {
-    VStack(alignment: .leading, spacing: 8) {
+    VStack(alignment: .leading, spacing: 4) {
       Text(mode.title)
-        .font(.title2.weight(.bold))
+        .font(.headline.weight(.bold))
       Text(mode.subtitle)
-        .font(.subheadline)
+        .font(.footnote)
         .foregroundStyle(.secondary)
         .fixedSize(horizontal: false, vertical: true)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
-  private var durationReadout: some View {
-    Text(currentDuration.shortLabel)
-      .font(.system(.largeTitle, design: .rounded).weight(.bold))
-      .minimumScaleFactor(0.7)
-      .frame(maxWidth: .infinity)
-      .padding(.vertical, 24)
-      .padding(.horizontal, 18)
-      .background(
-        RoundedRectangle(cornerRadius: 28, style: .continuous)
-          .fill(
-            LiquidGlassTokens.surfaceFill(
-              reducesTransparency: reducesTransparency,
-              fallback: Color(UIColor.secondarySystemBackground),
-              opacity: 0.20
-            )
+  private var durationEntryAndApplyRow: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .center, spacing: 12) {
+        durationEntryCard
+
+        Button {
+          applyDuration()
+        } label: {
+          VStack(spacing: 3) {
+            Image(systemName: "checkmark")
+              .font(.system(size: 20, weight: .bold))
+            Text(mode.compactApplyTitle)
+              .font(.caption.weight(.semibold))
+          }
+        }
+        .accessibilityIdentifier("custom_duration_apply_button")
+        .accessibilityLabel(mode.applyTitle(for: currentDuration))
+        .liquidGlassIconButtonStyle(variant: .prominent, role: .success, diameter: 68)
+      }
+
+      Text(validationMessage ?? "Tap the value to type, or use the slider for 1 min–2 hr.")
+        .font(.footnote)
+        .foregroundStyle(validationMessage == nil ? Color.secondary : Color.red)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private var durationEntryCard: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      TextField("Minutes", text: $minutesText)
+        .keyboardType(.numberPad)
+        .focused($isMinutesFieldFocused)
+        .multilineTextAlignment(.trailing)
+        .font(.system(.largeTitle, design: .rounded).weight(.bold))
+        .minimumScaleFactor(0.7)
+        .accessibilityIdentifier("custom_duration_minutes_field")
+        .accessibilityHint("Enter a duration in minutes; values over 2 hours are allowed.")
+        .onChange(of: minutesText) { _, newValue in
+          updateDraftMinutes(from: newValue)
+        }
+
+      Text("min")
+        .font(.headline.weight(.semibold))
+        .foregroundStyle(.secondary)
+    }
+    .padding(.vertical, 16)
+    .padding(.horizontal, 18)
+    .frame(maxWidth: .infinity, minHeight: 72)
+    .contentShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    .background(
+      RoundedRectangle(cornerRadius: 24, style: .continuous)
+        .fill(
+          LiquidGlassTokens.surfaceFill(
+            reducesTransparency: reducesTransparency,
+            fallback: Color(UIColor.secondarySystemBackground),
+            opacity: 0.20
           )
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 28, style: .continuous)
-          .stroke(
-            LiquidGlassTokens.surfaceStroke(reducesTransparency: reducesTransparency),
-            lineWidth: 1
-          )
-      )
-      .accessibilityLabel(currentDuration.accessibilityLabel)
+        )
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 24, style: .continuous)
+        .stroke(
+          LiquidGlassTokens.surfaceStroke(reducesTransparency: reducesTransparency),
+          lineWidth: 1
+        )
+    )
+    .onTapGesture { isMinutesFieldFocused = true }
+    .accessibilityLabel(currentDuration.accessibilityLabel)
   }
 
   private var sliderSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Quick set")
-        .font(.caption.weight(.semibold))
-        .textCase(.uppercase)
-        .foregroundStyle(.secondary)
-
+    VStack(alignment: .leading, spacing: 8) {
       Slider(
         value: sliderValue,
         in: Double(
@@ -140,50 +185,15 @@ struct CustomDurationSheet: View {
     }
   }
 
-  private var textInputSection: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      Text("Minutes")
-        .font(.caption.weight(.semibold))
-        .textCase(.uppercase)
-        .foregroundStyle(.secondary)
-
-      TextField("Minutes", text: $minutesText)
-        .keyboardType(.numberPad)
-        .focused($isMinutesFieldFocused)
-        .textFieldStyle(.roundedBorder)
-        .font(.title3.monospacedDigit())
-        .accessibilityIdentifier("custom_duration_minutes_field")
-        .accessibilityHint("Enter a duration in minutes; values over 2 hours are allowed.")
-        .onChange(of: minutesText) { _, newValue in
-          updateDraftMinutes(from: newValue)
-        }
-
-      Text(validationMessage ?? "Enter minutes, or use the slider for 1 min–2 hr.")
-        .font(.footnote)
-        .foregroundStyle(validationMessage == nil ? Color.secondary : Color.red)
-        .fixedSize(horizontal: false, vertical: true)
+  private var footerActions: some View {
+    Button {
+      onCancel()
+    } label: {
+      Text("Cancel")
+        .frame(maxWidth: .infinity)
     }
-  }
-
-  private var actions: some View {
-    VStack(spacing: 12) {
-      Button {
-        applyDuration()
-      } label: {
-        Label(mode.applyTitle(for: currentDuration), systemImage: "checkmark.circle.fill")
-      }
-      .accessibilityIdentifier("custom_duration_apply_button")
-      .liquidGlassButtonStyle(.prominent, controlHeight: LiquidGlassTokens.primaryControlHeight)
-
-      Button {
-        onCancel()
-      } label: {
-        Text("Cancel")
-          .frame(maxWidth: .infinity)
-      }
-      .accessibilityIdentifier("custom_duration_cancel_button")
-      .liquidGlassButtonStyle(.subtle, role: .neutral)
-    }
+    .accessibilityIdentifier("custom_duration_cancel_button")
+    .liquidGlassButtonStyle(.subtle, role: .neutral, controlHeight: 44)
   }
 
   private var backgroundSurface: some View {

--- a/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
+++ b/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+
+enum CustomDurationSheetMode: Equatable {
+  case start
+  case running
+
+  var title: String { "Custom duration" }
+
+  var subtitle: String {
+    switch self {
+    case .start:
+      return "Choose when the bell should end this session."
+    case .running:
+      return "Choose when the bell should end this session. Your timer keeps running."
+    }
+  }
+
+  func applyTitle(for duration: MeditationDuration) -> String {
+    switch self {
+    case .start:
+      return "Start \(duration.shortLabel) session"
+    case .running:
+      return "Set bell for \(duration.shortLabel)"
+    }
+  }
+}
+
+struct CustomDurationSheet: View {
+  let mode: CustomDurationSheetMode
+  let onApply: (MeditationDuration) -> Void
+  let onCancel: () -> Void
+
+  @Environment(\.accessibilityReduceTransparency) private var reducesTransparency
+  @FocusState private var isMinutesFieldFocused: Bool
+  @State private var draftMinutes: Int
+  @State private var minutesText: String
+  @State private var validationMessage: String?
+  @State private var lastHapticMinute: Int
+
+  init(
+    mode: CustomDurationSheetMode,
+    initialMinutes: Int,
+    onApply: @escaping (MeditationDuration) -> Void,
+    onCancel: @escaping () -> Void
+  ) {
+    self.mode = mode
+    self.onApply = onApply
+    self.onCancel = onCancel
+    _draftMinutes = State(initialValue: max(initialMinutes, MeditationDuration.minimumMinutes))
+    _minutesText = State(initialValue: "\(max(initialMinutes, MeditationDuration.minimumMinutes))")
+    _lastHapticMinute = State(initialValue: max(initialMinutes, MeditationDuration.minimumMinutes))
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 28) {
+        header
+        durationReadout
+        sliderSection
+        textInputSection
+        actions
+      }
+      .padding(.horizontal, 24)
+      .padding(.top, 28)
+      .padding(.bottom, 32)
+    }
+    .background(backgroundSurface)
+    .accessibilityIdentifier("custom_duration_sheet")
+    .toolbar {
+      ToolbarItemGroup(placement: .keyboard) {
+        Spacer()
+        Button("Done") { isMinutesFieldFocused = false }
+      }
+    }
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(mode.title)
+        .font(.title2.weight(.bold))
+      Text(mode.subtitle)
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var durationReadout: some View {
+    Text(currentDuration.shortLabel)
+      .font(.system(.largeTitle, design: .rounded).weight(.bold))
+      .minimumScaleFactor(0.7)
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 24)
+      .padding(.horizontal, 18)
+      .background(
+        RoundedRectangle(cornerRadius: 28, style: .continuous)
+          .fill(
+            LiquidGlassTokens.surfaceFill(
+              reducesTransparency: reducesTransparency,
+              fallback: Color(UIColor.secondarySystemBackground),
+              opacity: 0.20
+            )
+          )
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 28, style: .continuous)
+          .stroke(
+            LiquidGlassTokens.surfaceStroke(reducesTransparency: reducesTransparency),
+            lineWidth: 1
+          )
+      )
+      .accessibilityLabel(currentDuration.accessibilityLabel)
+  }
+
+  private var sliderSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Quick set")
+        .font(.caption.weight(.semibold))
+        .textCase(.uppercase)
+        .foregroundStyle(.secondary)
+
+      Slider(
+        value: sliderValue,
+        in: Double(
+          MeditationDuration.sliderMinimumMinutes)...Double(
+            MeditationDuration.sliderMaximumMinutes),
+        step: 1
+      )
+      .accessibilityIdentifier("custom_duration_slider")
+      .accessibilityValue(Text(currentDuration.accessibilityLabel))
+
+      HStack {
+        Text("1 min")
+        Spacer()
+        Text("2 hr")
+      }
+      .font(.caption)
+      .foregroundStyle(.secondary)
+    }
+  }
+
+  private var textInputSection: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("Minutes")
+        .font(.caption.weight(.semibold))
+        .textCase(.uppercase)
+        .foregroundStyle(.secondary)
+
+      TextField("Minutes", text: $minutesText)
+        .keyboardType(.numberPad)
+        .focused($isMinutesFieldFocused)
+        .textFieldStyle(.roundedBorder)
+        .font(.title3.monospacedDigit())
+        .accessibilityIdentifier("custom_duration_minutes_field")
+        .accessibilityHint("Enter a duration in minutes; values over 2 hours are allowed.")
+        .onChange(of: minutesText) { _, newValue in
+          updateDraftMinutes(from: newValue)
+        }
+
+      Text(validationMessage ?? "Enter minutes, or use the slider for 1 min–2 hr.")
+        .font(.footnote)
+        .foregroundStyle(validationMessage == nil ? Color.secondary : Color.red)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private var actions: some View {
+    VStack(spacing: 12) {
+      Button {
+        applyDuration()
+      } label: {
+        Label(mode.applyTitle(for: currentDuration), systemImage: "checkmark.circle.fill")
+      }
+      .accessibilityIdentifier("custom_duration_apply_button")
+      .liquidGlassButtonStyle(.prominent, controlHeight: LiquidGlassTokens.primaryControlHeight)
+
+      Button {
+        onCancel()
+      } label: {
+        Text("Cancel")
+          .frame(maxWidth: .infinity)
+      }
+      .accessibilityIdentifier("custom_duration_cancel_button")
+      .liquidGlassButtonStyle(.subtle, role: .neutral)
+    }
+  }
+
+  private var backgroundSurface: some View {
+    Group {
+      if reducesTransparency {
+        Color(UIColor.systemBackground)
+      } else {
+        LinearGradient(
+          colors: [
+            LiquidGlassTokens.primaryTint.opacity(0.10),
+            Color(UIColor.systemBackground),
+          ],
+          startPoint: .topLeading,
+          endPoint: .bottomTrailing
+        )
+      }
+    }
+    .ignoresSafeArea()
+  }
+
+  private var currentDuration: MeditationDuration {
+    if let duration = try? MeditationDuration(minutes: draftMinutes) {
+      return duration
+    }
+    return Self.minimumDuration ?? MeditationDuration.uncheckedMinimum
+  }
+
+  private static let minimumDuration = try? MeditationDuration(
+    minutes: MeditationDuration.minimumMinutes
+  )
+
+  private var sliderValue: Binding<Double> {
+    Binding(
+      get: {
+        Double(
+          min(
+            max(draftMinutes, MeditationDuration.sliderMinimumMinutes),
+            MeditationDuration.sliderMaximumMinutes
+          )
+        )
+      },
+      set: { newValue in
+        let minutes = MeditationDuration.clampedSliderMinutes(newValue)
+        draftMinutes = minutes
+        minutesText = "\(minutes)"
+        validationMessage = nil
+        provideSliderFeedbackIfNeeded(for: minutes)
+      }
+    )
+  }
+
+  private func updateDraftMinutes(from rawValue: String) {
+    switch MeditationDuration.parseMinutes(rawValue) {
+    case .success(let duration):
+      draftMinutes = duration.minutes
+      validationMessage = nil
+    case .failure(let error):
+      validationMessage = error.errorDescription
+    }
+  }
+
+  private func applyDuration() {
+    switch MeditationDuration.parseMinutes(minutesText) {
+    case .success(let duration):
+      validationMessage = nil
+      isMinutesFieldFocused = false
+      onApply(duration)
+    case .failure(let error):
+      validationMessage = error.errorDescription
+    }
+  }
+
+  private func provideSliderFeedbackIfNeeded(for minutes: Int) {
+    guard minutes != lastHapticMinute else { return }
+    defer { lastHapticMinute = minutes }
+
+    let shouldProvideFeedback =
+      minutes.isMultiple(of: 5)
+      || [30, 60, 120].contains(minutes)
+    guard shouldProvideFeedback else { return }
+
+    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+  }
+}
+
+struct CustomDurationSheet_Previews: PreviewProvider {
+  static var previews: some View {
+    CustomDurationSheet(mode: .start, initialMinutes: 25) { _ in
+    } onCancel: {
+    }
+  }
+}

--- a/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
+++ b/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 enum CustomDurationSheetMode: Equatable {
   case start
@@ -40,7 +41,6 @@ struct CustomDurationSheet: View {
   let onCancel: () -> Void
 
   @Environment(\.accessibilityReduceTransparency) private var reducesTransparency
-  @FocusState private var isMinutesFieldFocused: Bool
   @State private var draftMinutes: Int
   @State private var minutesText: String
   @State private var validationMessage: String?
@@ -73,12 +73,6 @@ struct CustomDurationSheet: View {
     .frame(maxWidth: .infinity, alignment: .topLeading)
     .background(backgroundSurface)
     .accessibilityIdentifier("custom_duration_sheet")
-    .toolbar {
-      ToolbarItemGroup(placement: .keyboard) {
-        Spacer()
-        Button("Done") { isMinutesFieldFocused = false }
-      }
-    }
   }
 
   private var header: some View {
@@ -122,13 +116,8 @@ struct CustomDurationSheet: View {
 
   private var durationEntryCard: some View {
     HStack(alignment: .firstTextBaseline, spacing: 8) {
-      TextField("Minutes", text: $minutesText)
-        .keyboardType(.numberPad)
-        .focused($isMinutesFieldFocused)
-        .multilineTextAlignment(.trailing)
-        .font(.system(.largeTitle, design: .rounded).weight(.bold))
-        .minimumScaleFactor(0.7)
-        .accessibilityIdentifier("custom_duration_minutes_field")
+      SelectAllMinutesTextField(text: $minutesText)
+        .frame(minHeight: 48)
         .accessibilityHint("Enter a duration in minutes; values over 2 hours are allowed.")
         .onChange(of: minutesText) { _, newValue in
           updateDraftMinutes(from: newValue)
@@ -159,7 +148,6 @@ struct CustomDurationSheet: View {
           lineWidth: 1
         )
     )
-    .onTapGesture { isMinutesFieldFocused = true }
     .accessibilityLabel(currentDuration.accessibilityLabel)
   }
 
@@ -259,11 +247,20 @@ struct CustomDurationSheet: View {
     switch MeditationDuration.parseMinutes(minutesText) {
     case .success(let duration):
       validationMessage = nil
-      isMinutesFieldFocused = false
+      dismissKeyboard()
       onApply(duration)
     case .failure(let error):
       validationMessage = error.errorDescription
     }
+  }
+
+  private func dismissKeyboard() {
+    UIApplication.shared.sendAction(
+      #selector(UIResponder.resignFirstResponder),
+      to: nil,
+      from: nil,
+      for: nil
+    )
   }
 
   private func provideSliderFeedbackIfNeeded(for minutes: Int) {
@@ -276,6 +273,81 @@ struct CustomDurationSheet: View {
     guard shouldProvideFeedback else { return }
 
     UIImpactFeedbackGenerator(style: .light).impactOccurred()
+  }
+}
+
+private struct SelectAllMinutesTextField: UIViewRepresentable {
+  @Binding var text: String
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+    textField.keyboardType = .numberPad
+    textField.textAlignment = .right
+    textField.font = UIFont.systemFont(ofSize: 34, weight: .bold)
+    textField.adjustsFontForContentSizeCategory = true
+    textField.minimumFontSize = 24
+    textField.adjustsFontSizeToFitWidth = true
+    textField.accessibilityIdentifier = "custom_duration_minutes_field"
+    textField.addTarget(
+      context.coordinator,
+      action: #selector(Coordinator.textDidChange(_:)),
+      for: .editingChanged
+    )
+    textField.inputAccessoryView = context.coordinator.makeToolbar()
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != text {
+      textField.text = text
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(text: $text)
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate {
+    @Binding private var text: String
+
+    init(text: Binding<String>) {
+      _text = text
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        textField.selectAll(nil)
+      }
+    }
+
+    @objc func textDidChange(_ textField: UITextField) {
+      text = textField.text ?? ""
+    }
+
+    @objc func doneTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder),
+        to: nil,
+        from: nil,
+        for: nil
+      )
+    }
+
+    func makeToolbar() -> UIToolbar {
+      let toolbar = UIToolbar()
+      toolbar.items = [
+        UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+        UIBarButtonItem(
+          title: "Done",
+          style: .done,
+          target: self,
+          action: #selector(doneTapped)
+        ),
+      ]
+      toolbar.sizeToFit()
+      return toolbar
+    }
   }
 }
 

--- a/LittleMoments/Features/Timer/Views/TimerRunningView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerRunningView.swift
@@ -14,6 +14,8 @@ struct TimerRunningView: View {
   @Environment(\.presentationMode) var presentationMode
   @Environment(\.horizontalSizeClass) var horizontalSizeClass
   @State private var liveActivityUpdateTimer: Timer?
+  @State private var showCustomDurationSheet = false
+  @AppStorage("lastCustomDurationMinutes") private var lastCustomDurationMinutes = 10
   @Environment(\.accessibilityReduceTransparency) private var reducesTransparency
   private let containerCornerRadius: CGFloat = 32
 
@@ -63,7 +65,7 @@ struct TimerRunningView: View {
         // Use a small delay to ensure Live Activity setup is complete
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
           print("📱 Applying preset duration: \(preset) seconds")
-          timerViewModel.applyPresetDuration(preset)
+          timerViewModel.setDurationTarget(seconds: preset)
           print(
             "📱 Applied preset duration, scheduledAlert: \(timerViewModel.scheduledAlert?.name ?? "nil")"
           )
@@ -89,6 +91,17 @@ struct TimerRunningView: View {
         }
       }
     }
+    .sheet(isPresented: $showCustomDurationSheet) {
+      CustomDurationSheet(
+        mode: .running,
+        initialMinutes: customDurationInitialMinutes,
+        onApply: applyCustomDuration,
+        onCancel: { showCustomDurationSheet = false }
+      )
+      .presentationDetents([.medium, .large])
+      .presentationDragIndicator(.visible)
+      .presentationCornerRadius(32)
+    }
     .onDisappear {
       print("📱 TimerRunningView disappeared - cleaning up timer resources")
       // Invalidate the live activity update timer
@@ -113,12 +126,31 @@ extension TimerRunningView {
   fileprivate var controlsContainer: some View {
     glassContainer {
       VStack(spacing: 24) {
-        BellControlsGrid(timerViewModel: timerViewModel)
-          .frame(maxWidth: .infinity, alignment: .leading)
+        BellControlsGrid(
+          timerViewModel: timerViewModel,
+          onCustomDurationTapped: { showCustomDurationSheet = true }
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
 
         TimerControlButtons(timerViewModel: timerViewModel, presentationMode: presentationMode)
       }
     }
+  }
+
+  fileprivate var customDurationInitialMinutes: Int {
+    if timerViewModel.hasCustomDurationTarget,
+      let targetSeconds = timerViewModel.scheduledAlert?.targetTimeInSec
+    {
+      return max(Int(targetSeconds / 60), MeditationDuration.minimumMinutes)
+    }
+    return lastCustomDurationMinutes
+  }
+
+  fileprivate func applyCustomDuration(_ duration: MeditationDuration) {
+    lastCustomDurationMinutes = duration.minutes
+    timerViewModel.setDurationTarget(minutes: duration.minutes)
+    showCustomDurationSheet = false
+    UIImpactFeedbackGenerator(style: .light).impactOccurred()
   }
 
   fileprivate func timerColumn(for size: CGSize) -> some View {
@@ -214,9 +246,28 @@ struct TimerCircleView: View {
 }
 
 // MARK: - Bell Controls Grid
+private enum TimerDurationGridItem {
+  case preset(OneTimeScheduledBellAlert)
+  case custom
+
+  var id: String {
+    switch self {
+    case .preset(let option):
+      return "preset-\(Int(option.targetTimeInSec))-\(option.name)"
+    case .custom:
+      return "custom"
+    }
+  }
+}
+
 struct BellControlsGrid: View {
   @ObservedObject var timerViewModel: TimerViewModel
+  let onCustomDurationTapped: () -> Void
   let buttonsPerRow = 4
+
+  private var gridItems: [TimerDurationGridItem] {
+    timerViewModel.scheduledAlertOptions.map(TimerDurationGridItem.preset) + [.custom]
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
@@ -226,26 +277,12 @@ struct BellControlsGrid: View {
         .foregroundStyle(Color.secondary)
 
       ForEach(
-        Array(timerViewModel.scheduledAlertOptions.chunked(into: buttonsPerRow).enumerated()),
+        Array(gridItems.chunked(into: buttonsPerRow).enumerated()),
         id: \.offset
       ) { _, row in
         HStack(spacing: 12) {
-          ForEach(row, id: \.targetTimeInSec) { option in
-            Button {
-              handleAlertSelection(option)
-            } label: {
-              Text(option.name)
-            }
-            .buttonStyle(.plain)
-            .liquidGlassChip(isSelected: timerViewModel.scheduledAlert == option)
-            .accessibilityIdentifier(
-              timerViewModel.scheduledAlert == option
-                ? "selected_duration_\(option.name)"
-                : "duration_\(option.name)"
-            )
-            .accessibilityAddTraits(
-              timerViewModel.scheduledAlert == option ? .isSelected : []
-            )
+          ForEach(row, id: \.id) { item in
+            gridButton(for: item)
           }
 
           if row.count < buttonsPerRow {
@@ -258,33 +295,76 @@ struct BellControlsGrid: View {
     }
   }
 
+  @ViewBuilder
+  private func gridButton(for item: TimerDurationGridItem) -> some View {
+    switch item {
+    case .preset(let option):
+      Button {
+        handleAlertSelection(option)
+      } label: {
+        Text(option.name)
+      }
+      .buttonStyle(.plain)
+      .liquidGlassChip(isSelected: timerViewModel.scheduledAlert == option)
+      .accessibilityIdentifier(
+        timerViewModel.scheduledAlert == option
+          ? "selected_duration_\(option.name)"
+          : "duration_\(option.name)"
+      )
+      .accessibilityAddTraits(
+        timerViewModel.scheduledAlert == option ? .isSelected : []
+      )
+    case .custom:
+      Button {
+        handleCustomSelection()
+      } label: {
+        Label(customButtonTitle, systemImage: "slider.horizontal.3")
+          .labelStyle(.titleAndIcon)
+      }
+      .buttonStyle(.plain)
+      .liquidGlassChip(isSelected: timerViewModel.hasCustomDurationTarget)
+      .accessibilityIdentifier("custom_duration_running_chip")
+      .accessibilityLabel(customAccessibilityLabel)
+      .accessibilityHint(customAccessibilityHint)
+      .accessibilityAddTraits(timerViewModel.hasCustomDurationTarget ? .isSelected : [])
+    }
+  }
+
+  private var customButtonTitle: String {
+    timerViewModel.customDurationLabel ?? "Custom"
+  }
+
+  private var customAccessibilityLabel: Text {
+    if let label = timerViewModel.customDurationLabel {
+      return Text("Custom duration, \(label), selected")
+    }
+    return Text("Custom duration")
+  }
+
+  private var customAccessibilityHint: Text {
+    if timerViewModel.hasCustomDurationTarget {
+      return Text("Clears the custom timer")
+    }
+    return Text("Opens custom duration settings")
+  }
+
   @MainActor
   private func handleAlertSelection(_ scheduledAlertOption: OneTimeScheduledBellAlert) {
     if timerViewModel.scheduledAlert == scheduledAlertOption {
-      // Clear selection and pending notifications on the main actor
-      timerViewModel.scheduledAlert = nil
-      UNUserNotificationCenter.current().removePendingNotificationRequests(
-        withIdentifiers: ["timerNotification"]
-      )
+      timerViewModel.clearDurationTarget()
     } else {
-      // Optimistically set selection on main actor
-      timerViewModel.scheduledAlert = scheduledAlertOption
+      timerViewModel.setDurationTarget(seconds: Int(scheduledAlertOption.targetTimeInSec))
+    }
+  }
 
-      // In tests with system integrations disabled, avoid scheduling notifications
-      if ProcessInfo.processInfo.arguments.contains("-DISABLE_SYSTEM_INTEGRATIONS") {
-        return
-      }
-
-      // Schedule a local notification via NotificationManager (Swift 6 safe)
-      Task {
-        try? await NotificationManager.shared.scheduleTimerNotification(
-          identifier: "timerNotification",
-          title: "Timer Complete",
-          body: "Your \(scheduledAlertOption.name) minute timer has finished",
-          soundName: "42095__fauxpress__bell-meditation.aif",
-          timeInterval: TimeInterval(scheduledAlertOption.targetTimeInSec)
-        )
-      }
+  @MainActor
+  private func handleCustomSelection() {
+    if timerViewModel.hasCustomDurationTarget {
+      timerViewModel.clearDurationTarget()
+      UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    } else {
+      onCustomDurationTapped()
+      UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
   }
 }

--- a/LittleMoments/Features/Timer/Views/TimerRunningView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerRunningView.swift
@@ -318,8 +318,7 @@ struct BellControlsGrid: View {
       Button {
         handleCustomSelection()
       } label: {
-        Label(customButtonTitle, systemImage: "slider.horizontal.3")
-          .labelStyle(.titleAndIcon)
+        customChipLabel
       }
       .buttonStyle(.plain)
       .liquidGlassChip(isSelected: timerViewModel.hasCustomDurationTarget)
@@ -330,8 +329,17 @@ struct BellControlsGrid: View {
     }
   }
 
-  private var customButtonTitle: String {
-    timerViewModel.customDurationLabel ?? "Custom"
+  @ViewBuilder
+  private var customChipLabel: some View {
+    if let label = timerViewModel.customDurationChipLabel {
+      Text(label)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+    } else {
+      Image(systemName: "slider.horizontal.3")
+        .font(.system(size: 18, weight: .semibold))
+        .imageScale(.medium)
+    }
   }
 
   private var customAccessibilityLabel: Text {

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -6,7 +6,8 @@ struct TimerStartView: View {
   @Environment(\.accessibilityReduceTransparency) private var reducesTransparency
   @AppStorage("lastCustomDurationMinutes") private var lastCustomDurationMinutes = 10
   @State private var showCustomDurationSheet = false
-  @State private var suppressNextStartTap = false
+  @State private var startPressWorkItem: DispatchWorkItem?
+  @State private var startLongPressTriggered = false
 
   var body: some View {
     NavigationStack {
@@ -80,11 +81,6 @@ struct TimerStartView: View {
 
   private var startButton: some View {
     Button {
-      if suppressNextStartTap {
-        suppressNextStartTap = false
-        return
-      }
-      startSession()
     } label: {
       Label("Start session", systemImage: "play.fill")
         .labelStyle(.titleAndIcon)
@@ -97,13 +93,43 @@ struct TimerStartView: View {
     )
     .accessibilityIdentifier("start_session_button")
     .accessibilityHint("Long-press to set a custom duration.")
-    .onLongPressGesture(minimumDuration: 0.45) {
-      suppressNextStartTap = true
-      showCustomDurationSheet = true
-      UIImpactFeedbackGenerator(style: .light).impactOccurred()
-      DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-        suppressNextStartTap = false
+    .accessibilityAction { startSession() }
+    .highPriorityGesture(startPressGesture)
+  }
+
+  private var startPressGesture: some Gesture {
+    DragGesture(minimumDistance: 0)
+      .onChanged { _ in
+        beginStartPressIfNeeded()
       }
+      .onEnded { _ in
+        finishStartPress()
+      }
+  }
+
+  private func beginStartPressIfNeeded() {
+    guard startPressWorkItem == nil else { return }
+
+    startLongPressTriggered = false
+    let workItem = DispatchWorkItem {
+      Task { @MainActor in
+        startLongPressTriggered = true
+        showCustomDurationSheet = true
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+      }
+    }
+    startPressWorkItem = workItem
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.45, execute: workItem)
+  }
+
+  private func finishStartPress() {
+    startPressWorkItem?.cancel()
+    startPressWorkItem = nil
+
+    if startLongPressTriggered {
+      startLongPressTriggered = false
+    } else {
+      startSession()
     }
   }
 

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -4,6 +4,9 @@ import SwiftUI
 struct TimerStartView: View {
   @StateObject private var appState = AppState.shared
   @Environment(\.accessibilityReduceTransparency) private var reducesTransparency
+  @AppStorage("lastCustomDurationMinutes") private var lastCustomDurationMinutes = 10
+  @State private var showCustomDurationSheet = false
+  @State private var suppressNextStartTap = false
 
   var body: some View {
     NavigationStack {
@@ -44,6 +47,17 @@ struct TimerStartView: View {
         .presentationDragIndicator(.visible)
         .presentationCornerRadius(32)
     }
+    .sheet(isPresented: $showCustomDurationSheet) {
+      CustomDurationSheet(
+        mode: .start,
+        initialMinutes: lastCustomDurationMinutes,
+        onApply: startCustomSession,
+        onCancel: { showCustomDurationSheet = false }
+      )
+      .presentationDetents([.medium, .large])
+      .presentationDragIndicator(.visible)
+      .presentationCornerRadius(32)
+    }
   }
 
   private func requestNotificationAuthorizationIfNeeded() {
@@ -60,12 +74,36 @@ struct TimerStartView: View {
     HStack(spacing: 20) {
       settingsButton
 
-      ImageButton(
-        imageName: "play.fill",
-        buttonText: "Start session",
-        action: startSession
-      )
-      .accessibilityIdentifier("start_session_button")
+      startButton
+    }
+  }
+
+  private var startButton: some View {
+    Button {
+      if suppressNextStartTap {
+        suppressNextStartTap = false
+        return
+      }
+      startSession()
+    } label: {
+      Label("Start session", systemImage: "play.fill")
+        .labelStyle(.titleAndIcon)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 4)
+    }
+    .liquidGlassButtonStyle(
+      .prominent,
+      controlHeight: LiquidGlassTokens.primaryControlHeight
+    )
+    .accessibilityIdentifier("start_session_button")
+    .accessibilityHint("Long-press to set a custom duration.")
+    .onLongPressGesture(minimumDuration: 0.45) {
+      suppressNextStartTap = true
+      showCustomDurationSheet = true
+      UIImpactFeedbackGenerator(style: .light).impactOccurred()
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        suppressNextStartTap = false
+      }
     }
   }
 
@@ -79,6 +117,13 @@ struct TimerStartView: View {
     .accessibilityLabel(Text("Settings"))
     .accessibilityIdentifier("settings_button")
     .liquidGlassIconButtonStyle(variant: .subtle, diameter: 64)
+  }
+
+  private func startCustomSession(_ duration: MeditationDuration) {
+    lastCustomDurationMinutes = duration.minutes
+    appState.pendingStartDurationSeconds = duration.seconds
+    showCustomDurationSheet = false
+    startSession()
   }
 
   private func startSession() {

--- a/LittleMoments/Tests/UITests/TimerDeepLinkUITests.swift
+++ b/LittleMoments/Tests/UITests/TimerDeepLinkUITests.swift
@@ -5,19 +5,17 @@ final class TimerDeepLinkUITests: XCTestCase {
 
   // MARK: - Deep Link UI Testing Issues
 
-  /*
-   * DO NOT RUN: This test is currently disabled due to XCUITest limitations
-   *
-   * ISSUE: XCUIApplication.open(URL(...)) relaunches the app instead of calling onOpenURL,
-   * preventing proper deep link testing in the UI test environment.
-   *
-   * SOLUTION REFERENCE: See `backlog/docs/doc-8 - Deep-Link-Testing-Strategy.md`
-   * - Consider alternative testing approaches (unit tests for deep link logic)
-   * - Investigate XCUITest workarounds or migration to unit test coverage
-   * - Core deep link functionality is already covered in DeepLinkTests.swift
-   */
+  // DO NOT RUN: This test is currently disabled due to XCUITest limitations.
+  //
+  // ISSUE: XCUIApplication.open(URL(...)) relaunches the app instead of calling onOpenURL,
+  // preventing proper deep link testing in the UI test environment.
+  //
+  // SOLUTION REFERENCE: See `backlog/docs/doc-8 - Deep-Link-Testing-Strategy.md`.
+  // - Consider alternative testing approaches (unit tests for deep link logic).
+  // - Investigate XCUITest workarounds or migration to unit test coverage.
+  // - Core deep link functionality is already covered in DeepLinkTests.swift.
 
-  func DISABLED_testCustomDurationHighlightedViaDeepLink() throws {
+  func disabledCustomDurationHighlightedViaDeepLink() throws {
     let app = XCUIApplication()
     continueAfterFailure = false
     app.launchArguments = ["UITesting", "-DISABLE_SYSTEM_INTEGRATIONS"]
@@ -26,8 +24,9 @@ final class TimerDeepLinkUITests: XCTestCase {
     app.open(URL(string: "littlemoments://startSession?duration=420")!)
     XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 5))
 
-    // Verify the temporary 7-minute option appears and is highlighted
-    let selectedSeven = app.buttons["selected_duration_7"]
-    XCTAssertTrue(selectedSeven.waitForExistence(timeout: 10))
+    // Verify the custom duration chip is highlighted for the 7-minute target
+    let selectedCustom = app.buttons["custom_duration_running_chip"]
+    XCTAssertTrue(selectedCustom.waitForExistence(timeout: 10))
+    XCTAssertTrue(selectedCustom.isSelected)
   }
 }

--- a/LittleMoments/Tests/UITests/TimerFlowUITests.swift
+++ b/LittleMoments/Tests/UITests/TimerFlowUITests.swift
@@ -83,8 +83,8 @@ final class TimerFlowUITests: XCTestCase {
   private func selectShortDuration(app: XCUIApplication) {
     if app.buttons["5 sec"].exists {
       app.buttons["5 sec"].tap()
-    } else if app.buttons["1"].exists {
-      app.buttons["1"].tap()
+    } else if app.buttons["5"].exists {
+      app.buttons["5"].tap()
     }
   }
 

--- a/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
+++ b/LittleMoments/Tests/UnitTests/CoreTests/DeepLinkTests.swift
@@ -82,6 +82,38 @@ final class DeepLinkTests: XCTestCase {
     XCTAssertEqual(AppState.shared.pendingStartDurationSeconds, 120)
   }
 
+  func testMeditationSessionIntentPerformAcceptsDurationOverTwoHours() {
+    AppState.shared.resetState()
+    var intent = MeditationSessionIntent()
+    intent.durationMinutes = 150
+    let exp = expectation(description: "intent perform")
+    Task {
+      _ = try? await intent.perform()
+      exp.fulfill()
+    }
+    wait(for: [exp], timeout: 2.0)
+    XCTAssertTrue(AppState.shared.showTimerRunningView)
+    XCTAssertEqual(AppState.shared.pendingStartDurationSeconds, 9_000)
+  }
+
+  func testMeditationSessionIntentPerformRejectsNonPositiveDuration() {
+    AppState.shared.resetState()
+    var intent = MeditationSessionIntent()
+    intent.durationMinutes = 0
+    let exp = expectation(description: "intent perform")
+    Task {
+      do {
+        _ = try await intent.perform()
+        XCTFail("Expected non-positive duration to throw")
+      } catch {
+        XCTAssertFalse(AppState.shared.showTimerRunningView)
+        XCTAssertNil(AppState.shared.pendingStartDurationSeconds)
+      }
+      exp.fulfill()
+    }
+    wait(for: [exp], timeout: 2.0)
+  }
+
   func testParseDurationHelper() throws {
     XCTAssertEqual(LittleMomentsApp.parseDurationToSeconds("60"), 60)
     XCTAssertEqual(LittleMomentsApp.parseDurationToSeconds("60s"), 60)

--- a/LittleMoments/Tests/UnitTests/TimerTests/MeditationDurationTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/MeditationDurationTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+
+@testable import LittleMoments
+
+final class MeditationDurationTests: XCTestCase {
+  func testFormattingShortLabels() throws {
+    XCTAssertEqual(try MeditationDuration(minutes: 1).shortLabel, "1 min")
+    XCTAssertEqual(try MeditationDuration(minutes: 59).shortLabel, "59 min")
+    XCTAssertEqual(try MeditationDuration(minutes: 60).shortLabel, "1 hr")
+    XCTAssertEqual(try MeditationDuration(minutes: 90).shortLabel, "1 hr 30 min")
+    XCTAssertEqual(try MeditationDuration(minutes: 120).shortLabel, "2 hr")
+    XCTAssertEqual(try MeditationDuration(minutes: 150).shortLabel, "2 hr 30 min")
+  }
+
+  func testAccessibilityLabels() throws {
+    XCTAssertEqual(try MeditationDuration(minutes: 1).accessibilityLabel, "1 minute")
+    XCTAssertEqual(try MeditationDuration(minutes: 2).accessibilityLabel, "2 minutes")
+    XCTAssertEqual(try MeditationDuration(minutes: 60).accessibilityLabel, "1 hour")
+    XCTAssertEqual(try MeditationDuration(minutes: 121).accessibilityLabel, "2 hours 1 minute")
+  }
+
+  func testParsingRejectsInvalidValues() {
+    XCTAssertEqual(MeditationDuration.parseMinutes(""), .failure(.empty))
+    XCTAssertEqual(MeditationDuration.parseMinutes("abc"), .failure(.notWholeMinutes))
+    XCTAssertEqual(MeditationDuration.parseMinutes("1.5"), .failure(.notWholeMinutes))
+    XCTAssertEqual(MeditationDuration.parseMinutes("0"), .failure(.belowMinimum))
+  }
+
+  func testParsingAcceptsValuesOverSliderMaximum() throws {
+    let result = MeditationDuration.parseMinutes("150")
+
+    guard case .success(let duration) = result else {
+      return XCTFail("Expected 150 minutes to parse successfully")
+    }
+    XCTAssertEqual(duration.minutes, 150)
+  }
+
+  func testSliderMinutesClampToOneThroughTwoHours() {
+    XCTAssertEqual(MeditationDuration.clampedSliderMinutes(-10), 1)
+    XCTAssertEqual(MeditationDuration.clampedSliderMinutes(25.4), 25)
+    XCTAssertEqual(MeditationDuration.clampedSliderMinutes(140), 120)
+  }
+}

--- a/LittleMoments/Tests/UnitTests/TimerTests/TimerPresetDurationTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/TimerPresetDurationTests.swift
@@ -4,86 +4,64 @@ import XCTest
 
 @MainActor
 final class TimerPresetDurationTests: XCTestCase {
-
-  func testApplyPresetDuration420() throws {
+  func testDefaultPresetDurationsReserveCustomSlot() throws {
     let timerViewModel = TimerViewModel()
 
-    // Check initial state
     XCTAssertNil(timerViewModel.scheduledAlert)
-    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 8)  // Default options
+    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 7)
 
-    // Apply 420 seconds (7 minutes)
-    timerViewModel.applyPresetDuration(420)
-
-    // Check that the count is still 8 (temporary option added, last option removed)
-    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 8)
-
-    // Check that the first option is the temporary 7-minute option
-    let firstOption = timerViewModel.scheduledAlertOptions[0]
-    XCTAssertEqual(firstOption.name, "7")
-    XCTAssertEqual(Int(firstOption.targetTimeInSec), 420)
-
-    // Check that this option is selected
-    XCTAssertNotNil(timerViewModel.scheduledAlert)
-    XCTAssertEqual(timerViewModel.scheduledAlert, firstOption)
-    XCTAssertEqual(timerViewModel.scheduledAlert?.name, "7")
+    #if targetEnvironment(simulator)
+      let expectedNames = ["5 sec", "10", "15", "20", "30", "45", "60"]
+    #else
+      let expectedNames = ["5", "10", "15", "20", "30", "45", "60"]
+    #endif
+    XCTAssertEqual(timerViewModel.scheduledAlertOptions.map(\.name), expectedNames)
   }
 
-  func testApplyPresetDuration315() throws {
+  func testApplyPresetDurationCreatesCustomTargetWithoutChangingPresetList() throws {
     let timerViewModel = TimerViewModel()
 
-    // Apply 315 seconds (5 minutes 15 seconds - not evenly divisible by 60)
+    timerViewModel.applyPresetDuration(420)
+
+    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 7)
+    XCTAssertEqual(timerViewModel.scheduledAlert?.name, "7")
+    XCTAssertEqual(Int(timerViewModel.scheduledAlert?.targetTimeInSec ?? 0), 420)
+    XCTAssertTrue(timerViewModel.hasCustomDurationTarget)
+    XCTAssertEqual(timerViewModel.customDurationLabel, "7")
+  }
+
+  func testApplyPresetDurationSupportsNonMinuteTarget() throws {
+    let timerViewModel = TimerViewModel()
+
     timerViewModel.applyPresetDuration(315)
 
-    // Check that a temporary option was created with "315s" label
-    let firstOption = timerViewModel.scheduledAlertOptions[0]
-    XCTAssertEqual(firstOption.name, "315s")
-    XCTAssertEqual(Int(firstOption.targetTimeInSec), 315)
-
-    // Check that this option is selected
-    XCTAssertEqual(timerViewModel.scheduledAlert, firstOption)
+    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 7)
+    XCTAssertEqual(timerViewModel.scheduledAlert?.name, "315s")
+    XCTAssertEqual(Int(timerViewModel.scheduledAlert?.targetTimeInSec ?? 0), 315)
+    XCTAssertTrue(timerViewModel.hasCustomDurationTarget)
   }
 
-  func testApplyPresetDurationExistingOption() throws {
+  func testApplyPresetDurationExistingOptionSelectsPreset() throws {
     let timerViewModel = TimerViewModel()
 
-    // Apply 300 seconds (5 minutes - should match existing option)
-    timerViewModel.applyPresetDuration(300)
+    timerViewModel.applyPresetDuration(600)
 
-    // Should not create a new option (still 8 total)
-    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 8)
-
-    // Should select the existing 5-minute option
+    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 7)
     XCTAssertNotNil(timerViewModel.scheduledAlert)
-    XCTAssertEqual(timerViewModel.scheduledAlert?.name, "5")
-    XCTAssertEqual(Int(timerViewModel.scheduledAlert!.targetTimeInSec), 300)
+    XCTAssertEqual(timerViewModel.scheduledAlert?.name, "10")
+    XCTAssertEqual(Int(timerViewModel.scheduledAlert?.targetTimeInSec ?? 0), 600)
+    XCTAssertFalse(timerViewModel.hasCustomDurationTarget)
   }
 
-  func testTemporaryOptionRemoval() throws {
+  func testClearDurationTargetClearsPresetAndCustomTargets() throws {
     let timerViewModel = TimerViewModel()
 
-    // Store reference to the last option before adding temporary
-    let originalLastOption = timerViewModel.scheduledAlertOptions.last!
-    XCTAssertEqual(originalLastOption.name, "60")  // 60 minutes
-
-    // Apply 420 seconds (7 minutes) - creates temporary option
     timerViewModel.applyPresetDuration(420)
+    XCTAssertNotNil(timerViewModel.scheduledAlert)
 
-    // Verify the temporary option is at the front and last option was removed
-    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 8)
-    XCTAssertEqual(timerViewModel.scheduledAlertOptions[0].name, "7")
-    XCTAssertNotEqual(timerViewModel.scheduledAlertOptions.last!.name, "60")  // 60min option should be gone
+    timerViewModel.clearDurationTarget()
 
-    // Apply an existing option (should remove temporary and restore removed option)
-    timerViewModel.applyPresetDuration(300)  // 5 minutes
-
-    // Verify count is still 8 and temporary option is gone
-    XCTAssertEqual(timerViewModel.scheduledAlertOptions.count, 8)
-    XCTAssertNotEqual(timerViewModel.scheduledAlertOptions[0].name, "7")  // Temporary should be gone
-
-    // Check if the 60-minute option was restored
-    let has60MinOption = timerViewModel.scheduledAlertOptions.contains { $0.name == "60" }
-    XCTAssertTrue(
-      has60MinOption, "60-minute option should be restored when temporary option is removed")
+    XCTAssertNil(timerViewModel.scheduledAlert)
+    XCTAssertFalse(timerViewModel.hasCustomDurationTarget)
   }
 }

--- a/LittleMoments/Tests/UnitTests/TimerTests/TimerTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/TimerTests.swift
@@ -59,7 +59,8 @@ final class TimerTests: XCTestCase {
 
     // Wait for 1 second to elapse
     let expectation = XCTestExpectation(description: "Timer running")
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) { [weak self] in  // Wait just over 1 second
+    // Wait just over 1 second.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) { [weak self] in
       Task { @MainActor in
         guard let self else { return }
         // Test with showSeconds = true
@@ -92,16 +93,16 @@ final class TimerTests: XCTestCase {
       // This shorter duration makes testing faster in the simulator
       XCTAssertEqual(timerViewModel?.scheduledAlert?.targetTimeInSec, 5)
     #else
-      // On device, first alert should be 3 minutes (180 seconds)
-      // This is the actual production value used in the app
-      XCTAssertEqual(timerViewModel?.scheduledAlert?.targetTimeInSec, 180)
+      // On device, first alert should be 5 minutes (300 seconds)
+      // This is the first production preset now that the 1-minute preset is removed
+      XCTAssertEqual(timerViewModel?.scheduledAlert?.targetTimeInSec, 300)
     #endif
   }
 
   /// Tests that the timer properly tracks progress
   /// Uses an async expectation to verify timer behavior over time
   func testTimerProgress() {
-    let fiveMinAlert = timerViewModel?.scheduledAlertOptions[1]  // 5-minute timer
+    let fiveMinAlert = timerViewModel?.scheduledAlertOptions[0]  // 5-minute timer
     timerViewModel?.scheduledAlert = fiveMinAlert
 
     timerViewModel?.start()

--- a/LittleMoments/Tests/UnitTests/TimerTests/TimerViewModelLiveActivityTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/TimerViewModelLiveActivityTests.swift
@@ -31,7 +31,7 @@ final class TimerViewModelLiveActivityTests: XCTestCase {
 
   func testStartLiveActivityWithTarget() {
     // Set a target time for the session
-    let fiveMinAlert = timerViewModel?.scheduledAlertOptions[1]  // 5-minute timer
+    let fiveMinAlert = timerViewModel?.scheduledAlertOptions[0]  // 5-minute timer
     timerViewModel?.scheduledAlert = fiveMinAlert
 
     // Start Live Activity with target

--- a/backlog/docs/doc-24 - Feature-Custom-Meditation-Duration.md
+++ b/backlog/docs/doc-24 - Feature-Custom-Meditation-Duration.md
@@ -3,7 +3,7 @@ id: doc-24
 title: 'Feature: Custom Meditation Duration'
 type: specification
 created_date: '2026-06-09 14:25'
-updated_date: '2026-06-09 14:57'
+updated_date: '2026-06-10 11:15'
 tags:
   - feature
   - spec
@@ -58,45 +58,42 @@ Use a sheet rather than a full-screen replacement so the feature feels optional 
 - **iPad / landscape:** allow the sheet to size comfortably as a centered form or large detent while preserving a visible running timer in the background when possible.
 
 ### Layout and Spacing
-Use a single, focused vertical layout with generous spacing:
+Use a single, focused vertical layout with generous spacing. The sheet has one job in both entry contexts: set when the bell should sound. The start and running flows may use different action verbs, but the editor should not feel like two different experiences.
 
 1. **Header block**
    - Title: “Custom duration”.
-   - Subtitle: “Choose when the bell should end this session.”
-   - Optional context line on the running screen: “Your timer is still running.”
+   - Subtitle: “Set when the bell should sound.”
+   - Avoid over-emphasizing whether the session is already running or about to start; that distinction belongs primarily in the primary action label.
    - Use 24 pt horizontal padding and 24–32 pt vertical spacing between major groups, aligning with the existing start/running screens.
 
-2. **Large duration readout**
-   - Centered prominent text, e.g. “25 min” or “1 hr 30 min”.
-   - Use a large rounded rectangle / Liquid Glass card with the accent tint at low opacity.
-   - Update live as slider or text input changes.
+2. **Stable duration field**
+   - Use one fixed-height Liquid Glass numeric field for the selected duration rather than separate “display” and “editing” controls.
+   - Show the editable minute value prominently with a trailing “min” label.
+   - Treat this field as the authoritative duration readout; do not add a second large label that competes with the editable value.
+   - The field is not focused by default, updates live as the slider changes, and can be tapped for precise typed entry.
+   - Focus should never change the field’s height or the sheet’s visual hierarchy; editing state may show selection/caret affordances only.
+   - The field should remain compact enough to sit in a horizontal control row with the sheet actions on standard iPhone portrait widths.
 
-3. **Slider section**
+3. **Sheet actions**
+   - Place Cancel and the primary action in the same horizontal control row as the duration field when space permits, with the primary action trailing.
+   - Use a compact primary label: “Start” from the Start screen, “Set” from the Timer Running screen.
+   - Accessibility labels should include the full consequence and duration, e.g. “Start 25 min session” or “Set bell for 25 min”.
+   - If horizontal space is constrained, wrap the actions below the field while preserving the same visual grouping.
+
+4. **Slider section**
    - Slider range: 1...120 minutes.
    - Step: 1 minute.
    - Min/max labels: “1 min” and “2 hr”.
    - Include subtle tick labels at helpful milestones if space allows: 15, 30, 60, 90, 120. Avoid dense tick marks that clutter the calm design.
    - Provide haptic selection feedback at meaningful boundaries such as 5-minute increments, 30 minutes, 60 minutes, and 120 minutes.
 
-4. **Text input section**
-   - Label: “Minutes”.
-   - Numeric text field using `.numberPad`, constrained to whole minutes.
-   - Optional stepper with minus/plus controls for one-minute nudges if it does not crowd the sheet.
-   - Text entry should accept any positive whole-minute value. Invalid or partial input should not immediately punish the user; validate on commit/apply and show inline guidance.
+5. **Validation and keyboard behavior**
+   - Numeric text entry should accept any positive whole-minute value. Invalid or partial input should not immediately punish the user; validate on commit/apply and show inline guidance.
    - Inline helper/error examples:
-     - Normal: “Enter minutes, or use the slider for 1 min–2 hr.”
+     - Normal: “Tap the value to type, or use the slider for 1 min–2 hr.”
      - Empty while editing: “Add a duration before applying.”
      - Zero/negative: “Enter at least 1 minute.”
-
-5. **Sheet actions**
-   - When opened from the launch/home Start button:
-     - Primary: “Start 25 min session”. Applies duration, donates the intent, dismisses the custom-duration sheet, and starts the timer.
-     - Secondary: “Cancel”. Dismisses the sheet without starting.
-     - Optional tertiary text button: “Start without timer” only if usability testing suggests users need it here; default tap Start already covers this.
-   - When opened from the Timer Running screen:
-     - Primary: “Set bell for 25 min”. Applies a new end target relative to session start, schedules/updates notification, updates Live Activity, and dismisses the custom-duration sheet.
-     - Secondary: “Cancel”. Dismisses the sheet without changes.
-     - Clearing an active timer target should happen by tapping the active preset/custom chip again in the timer grid, matching the existing preset-toggle behavior, rather than through a separate sheet action.
+   - Use safe-area-aware keyboard controls, preferably SwiftUI keyboard toolbar placement. Avoid custom input accessory views that can be clipped by the sheet or device edge.
 
 ### Visual Style
 - Reuse existing Liquid Glass button, chip, and surface treatments so the sheet feels native to the app.
@@ -109,10 +106,10 @@ Use a single, focused vertical layout with generous spacing:
 - Respect Reduce Transparency with solid system backgrounds, matching current Liquid Glass wrappers.
 
 ### Accessibility
-- VoiceOver order: title, explanation, current duration, slider, text input, helper/error text, primary action, secondary actions.
+- VoiceOver order: title, explanation, duration field, helper/error text, Cancel, primary action, slider.
 - Slider accessibility value should speak formatted duration, e.g. “25 minutes” or “1 hour 30 minutes”.
 - Text field should have an accessibility hint: “Enter a duration in minutes; values over 2 hours are allowed when typed.”
-- Dynamic Type: large readout can wrap to two lines; controls should remain reachable without overlapping.
+- Dynamic Type: the duration field may scale the numeric text down within its fixed height; controls should remain reachable without overlapping.
 - Button labels should include the selected duration, not only “Apply”.
 - Add accessibility identifiers for UI tests:
   - `custom_duration_sheet`

--- a/backlog/docs/doc-24 - Feature-Custom-Meditation-Duration.md
+++ b/backlog/docs/doc-24 - Feature-Custom-Meditation-Duration.md
@@ -1,0 +1,297 @@
+---
+id: doc-24
+title: 'Feature: Custom Meditation Duration'
+type: specification
+created_date: '2026-06-09 14:25'
+updated_date: '2026-06-09 14:57'
+tags:
+  - feature
+  - spec
+---
+# Feature: Custom Meditation Duration
+
+## Overview
+
+### Problem Statement
+The app currently makes timed sessions available through a small set of preset timer chips. Users who want a precise meditation length—such as 7 minutes, 22 minutes, 75 minutes, or a 2-hour sit—must either choose the nearest preset or rely on external tooling. This creates friction for deliberate practice and for Shortcuts that already support a custom duration parameter.
+
+### Intended Impact
+Add an optional custom-duration screen that keeps the default “tap Start and begin” flow fast while giving users a calm, precise way to set a meditation duration. The slider should cover 1 minute through 2 hours for quick selection, while typed entry and Shortcuts should allow longer positive whole-minute durations when users intentionally need them. The design should feel native to the existing Liquid Glass visual language, work during an active session, and use the same duration model across in-app controls, long-press start, deep links, widgets/controls, and Shortcuts/App Intents.
+
+### Background Context
+The current app already has the core pieces needed for this feature:
+
+- `TimerStartView` has a primary start button that donates `MeditationSessionIntent` and presents `TimerRunningView`.
+- `AppState.pendingStartDurationSeconds` already carries an optional duration into `TimerRunningView`.
+- `TimerRunningView` applies the pending duration after it starts, then clears it.
+- `BellControlsGrid` currently renders scheduled duration options in a 4-column chip grid.
+- `MeditationSessionIntent` has an optional `durationMinutes` parameter, but it should be tightened to share the same bounds and validation as the new UI.
+
+## Goals and Success Metrics
+
+### Primary Goals
+1. Preserve the fastest path: tapping Start still begins an untimed session immediately.
+2. Add a discoverable long-press path from Start to a custom duration screen.
+3. Add a running-session control in the final timer-chip slot so users can set or adjust the end target while meditating.
+4. Normalize duration handling so slider input clamps to 1–120 minutes, while typed input, deep links, and Shortcuts validate positive whole-minute values without imposing a 2-hour maximum.
+5. Provide clear tactile, visual, and accessibility feedback when a custom duration is opened, applied, adjusted, or cleared.
+
+### Success Metrics
+- Users can set any whole-minute duration from 1 to 120 minutes with the slider, or type longer positive whole-minute durations without leaving the meditation flow.
+- A custom duration can be entered with either a slider or text input and both stay synchronized.
+- Shortcuts with a custom duration produce the same timer state as the in-app custom screen.
+- UI tests can identify and exercise the Start long-press entry point, running-session custom chip, typed duration field, slider, sheet apply action, and active-chip clear behavior.
+
+### Non-goals
+- Second-level custom precision for production UI. Simulator-only test presets may continue to use second-level durations.
+- Multiple saved custom presets.
+- Full scheduling templates or interval-bell configuration.
+- Replacing the existing preset timer chips.
+
+## Experience Design
+
+### Screen Form Factor
+Use a sheet rather than a full-screen replacement so the feature feels optional and reversible:
+
+- **From Start screen:** present a bottom sheet with medium and large detents. The medium detent should be the default on iPhone portrait so users can set a duration and start without losing context.
+- **From Timer Running screen:** present the same sheet over the running timer. The timer remains active unless the user explicitly applies a new target, clears the target, cancels the sheet, completes the session, or cancels the session.
+- **iPad / landscape:** allow the sheet to size comfortably as a centered form or large detent while preserving a visible running timer in the background when possible.
+
+### Layout and Spacing
+Use a single, focused vertical layout with generous spacing:
+
+1. **Header block**
+   - Title: “Custom duration”.
+   - Subtitle: “Choose when the bell should end this session.”
+   - Optional context line on the running screen: “Your timer is still running.”
+   - Use 24 pt horizontal padding and 24–32 pt vertical spacing between major groups, aligning with the existing start/running screens.
+
+2. **Large duration readout**
+   - Centered prominent text, e.g. “25 min” or “1 hr 30 min”.
+   - Use a large rounded rectangle / Liquid Glass card with the accent tint at low opacity.
+   - Update live as slider or text input changes.
+
+3. **Slider section**
+   - Slider range: 1...120 minutes.
+   - Step: 1 minute.
+   - Min/max labels: “1 min” and “2 hr”.
+   - Include subtle tick labels at helpful milestones if space allows: 15, 30, 60, 90, 120. Avoid dense tick marks that clutter the calm design.
+   - Provide haptic selection feedback at meaningful boundaries such as 5-minute increments, 30 minutes, 60 minutes, and 120 minutes.
+
+4. **Text input section**
+   - Label: “Minutes”.
+   - Numeric text field using `.numberPad`, constrained to whole minutes.
+   - Optional stepper with minus/plus controls for one-minute nudges if it does not crowd the sheet.
+   - Text entry should accept any positive whole-minute value. Invalid or partial input should not immediately punish the user; validate on commit/apply and show inline guidance.
+   - Inline helper/error examples:
+     - Normal: “Enter minutes, or use the slider for 1 min–2 hr.”
+     - Empty while editing: “Add a duration before applying.”
+     - Zero/negative: “Enter at least 1 minute.”
+
+5. **Sheet actions**
+   - When opened from the launch/home Start button:
+     - Primary: “Start 25 min session”. Applies duration, donates the intent, dismisses the custom-duration sheet, and starts the timer.
+     - Secondary: “Cancel”. Dismisses the sheet without starting.
+     - Optional tertiary text button: “Start without timer” only if usability testing suggests users need it here; default tap Start already covers this.
+   - When opened from the Timer Running screen:
+     - Primary: “Set bell for 25 min”. Applies a new end target relative to session start, schedules/updates notification, updates Live Activity, and dismisses the custom-duration sheet.
+     - Secondary: “Cancel”. Dismisses the sheet without changes.
+     - Clearing an active timer target should happen by tapping the active preset/custom chip again in the timer grid, matching the existing preset-toggle behavior, rather than through a separate sheet action.
+
+### Visual Style
+- Reuse existing Liquid Glass button, chip, and surface treatments so the sheet feels native to the app.
+- Prefer one accented primary action per screen.
+- Keep destructive semantics only for session cancellation, not for clearing a timer target.
+- Use semantic colors for feedback:
+  - Accent for active/custom timer.
+  - Secondary for neutral helper text.
+  - System red only for validation errors.
+- Respect Reduce Transparency with solid system backgrounds, matching current Liquid Glass wrappers.
+
+### Accessibility
+- VoiceOver order: title, explanation, current duration, slider, text input, helper/error text, primary action, secondary actions.
+- Slider accessibility value should speak formatted duration, e.g. “25 minutes” or “1 hour 30 minutes”.
+- Text field should have an accessibility hint: “Enter a duration in minutes; values over 2 hours are allowed when typed.”
+- Dynamic Type: large readout can wrap to two lines; controls should remain reachable without overlapping.
+- Button labels should include the selected duration, not only “Apply”.
+- Add accessibility identifiers for UI tests:
+  - `custom_duration_sheet`
+  - `custom_duration_slider`
+  - `custom_duration_minutes_field`
+  - `custom_duration_apply_button`
+  - `custom_duration_cancel_button`
+  - `custom_duration_running_chip`
+
+## App Integration Design
+
+### Start Screen Entry Point
+The Start button keeps its existing tap behavior:
+
+1. Tap Start → immediately start an untimed session.
+2. Long-press Start → open the custom duration sheet.
+3. Sheet primary action → set `AppState.pendingStartDurationSeconds`, donate `MeditationSessionIntent(durationMinutes:)`, and present `TimerRunningView`.
+
+Recommended interaction details:
+
+- Add a subtle hint around the Start control, such as a context menu preview title or accessibility hint: “Long-press to set a custom duration.”
+- Use `onLongPressGesture` or a `contextMenu`-backed interaction only if it does not interfere with normal tap responsiveness. The implementation must ensure a long press does not also trigger the immediate Start action.
+- Provide light haptic feedback when the custom sheet opens.
+
+### Timer Running Entry Point
+Reserve the final timer-chip slot for custom duration:
+
+- Keep the 4-column grid shape, but treat the bottom-right slot as a dedicated “Custom” control.
+- The existing preset list should become seven visible presets plus one custom chip: 5, 10, 15, 20, 30, 45, 60, Custom. This removes the current 1-minute preset because very short custom sessions remain available through typed entry and the slider, while the grid keeps more useful longer-session presets.
+- Custom chip states:
+  - No custom target: label “Custom” with `slider.horizontal.3` or `timer` symbol.
+  - Active custom target: label the formatted duration, e.g. “75 min”, with selected chip styling.
+  - Recently applied: brief checkmark/success feedback or haptic confirmation.
+- Tapping Custom opens the custom duration sheet over the running timer.
+- Applying from the sheet should update the same scheduled alert pathway as presets, including local notification rescheduling, timer progress target, and Live Activity updates.
+
+### Duration Model
+Create one shared value type or utility to avoid divergent validation:
+
+- Name suggestion: `MeditationDuration` or `TimerDuration`.
+- Bounds: `minimumMinutes = 1` globally. Slider-specific bounds are `sliderMinimumMinutes = 1` and `sliderMaximumMinutes = 120`; typed, deep-link, and Shortcut values may exceed 120 when they are positive whole minutes.
+- Storage: whole minutes for user-facing UI; seconds for `TimerViewModel` and notifications.
+- Formatting:
+  - 1 minute → “1 min” / “1 minute” for accessibility.
+  - 59 minutes → “59 min”.
+  - 60 minutes → “1 hr”.
+  - 90 minutes → “1 hr 30 min”.
+  - 120 minutes → “2 hr”.
+  - 150 minutes → “2 hr 30 min”.
+- Parsing:
+  - Accept digits only in v1.
+  - Trim whitespace.
+  - Clamp slider values to 1...120; validate typed values as positive whole minutes before applying, with no upper cap.
+
+### TimerViewModel and Notification Flow
+Introduce a single method for setting a timed end target, then call it from presets, custom sheet, pending start duration, and intents:
+
+- Suggested API: `setDurationTarget(minutes:source:)` or `applyDuration(seconds:source:)`.
+- Responsibilities:
+  - Update `scheduledAlert` or replace it with a more general selected-duration state.
+  - Schedule or reschedule `timerNotification` unless system integrations are disabled.
+  - Update Live Activity with the target duration so the Lock Screen/Dynamic Island can show progress consistently.
+  - Provide completion feedback only when the session ends, not when a duration is merely set.
+
+Because the current model uses `OneTimeScheduledBellAlert`, implementation can either:
+
+1. Extend `OneTimeScheduledBellAlert` to represent arbitrary minute values and custom labels, or
+2. Introduce a neutral `TimerTarget` model and adapt presets/custom durations to it.
+
+Option 2 is cleaner long-term because it separates “preset button option” from “currently selected target,” but Option 1 is a lower-risk migration if this feature should be small.
+
+### Shortcut / Intent Integration
+Unify the existing Shortcuts parameter with the new validation model:
+
+- Keep a single discoverable `MeditationSessionIntent` with optional `durationMinutes`.
+- Add a lower-bound parameter constraint if App Intents supports the desired validation/UX on the deployment target; otherwise manually validate in `perform()`. Do not add an upper-bound constraint of 120 minutes.
+- Behavior:
+  - Missing duration → start untimed session.
+  - Positive whole-minute duration → set pending duration and start session, including values greater than 120 minutes.
+  - Less than 1 → reject with a friendly intent error.
+- Update App Shortcut phrases and descriptions to make custom duration discoverable, e.g. “Start a timed meditation in Little Moments.”
+- Widget/control open intents that remain hidden from Shortcuts can optionally accept a duration in future, but the user-facing custom-duration Shortcut should remain `MeditationSessionIntent` to avoid duplicate actions.
+
+### Deep Links and Widgets
+If deep links or widgets pass duration through `AppState.pendingStartDurationSeconds`, route them through the same shared validator before setting pending state. The app should never start with a silent invalid target.
+
+## User Flows
+
+### Flow A: Default Start
+1. User taps Start.
+2. App donates an untimed meditation intent.
+3. Running timer opens immediately.
+4. No scheduled end target is selected.
+
+### Flow B: Long-Press Custom Start
+1. User long-presses Start.
+2. Custom duration sheet opens with a sensible default, e.g. last custom duration if stored, otherwise 10 minutes.
+3. User drags slider to 25 minutes or types 25.
+4. User taps “Start 25 min session”.
+5. Sheet dismisses, running timer opens, 25-minute target is applied, notification and Live Activity target are updated.
+
+### Flow C: Adjust While Running
+1. User starts an untimed or preset session.
+2. User taps the bottom-right Custom chip.
+3. Sheet opens over the running timer.
+4. User sets 75 minutes.
+5. User taps “Set bell for 1 hr 15 min”.
+6. Custom chip becomes selected with the formatted value and the timer progress target updates.
+
+### Flow D: Shortcut Custom Duration
+1. User runs “Start Meditation Session” from Shortcuts with Duration = 45.
+2. Intent validates 45 minutes.
+3. App foregrounds and opens the running timer.
+4. The same 45-minute target is applied as if chosen in the custom sheet.
+
+## Edge Cases
+
+- **Long-press then cancel:** no session starts and pending duration remains unchanged.
+- **Typed empty value:** disable Apply and show helper text.
+- **Typed 0 or negative:** show validation error; do not apply.
+- **Shortcut invalid duration:** return an intent failure message rather than starting with an unexpected duration.
+- **Apply while timer is already complete:** either restart target calculations from session start only if the session is still active, or disable custom changes once `timerViewModel.isDone` is true.
+- **Preset selected after custom:** preset chip becomes selected and custom chip returns to neutral state.
+- **Custom selected after preset:** preset selection clears and custom chip becomes selected.
+- **Notifications disabled:** app still tracks visual target; notification scheduling fails gracefully with existing non-blocking behavior.
+- **Reduce Motion / Reduce Transparency:** avoid relying solely on animation/glass blur for feedback.
+
+## Implementation Plan
+
+### Phase 1: Shared Duration Model
+- Add a shared duration utility/model with bounds, seconds conversion, formatting, and parsing.
+- Add unit tests for bounds, formatting, and typed input validation.
+
+### Phase 2: Custom Duration Sheet
+- Build a reusable SwiftUI sheet view that accepts mode: `.start` or `.running`.
+- Wire slider and text input to the same draft duration state.
+- Add validation, accessibility identifiers, and Dynamic Type-friendly layout.
+
+### Phase 3: Start Screen Integration
+- Add Start long-press behavior and accessibility hint.
+- On apply, set pending duration, donate the typed-duration intent, and start the running timer.
+- Add UI tests for long-press entry and apply/cancel behavior.
+
+### Phase 4: Running Timer Integration
+- Reserve the last chip slot for Custom.
+- Refactor preset/custom application into one TimerViewModel duration-target method.
+- Add selected/confirmed feedback for the custom chip.
+- Add UI tests for opening the custom sheet while running and applying/clearing a target.
+
+### Phase 5: Shortcuts and Deep-Link Validation
+- Apply shared validation in `MeditationSessionIntent.perform()`.
+- Update Shortcuts descriptions/phrases if needed.
+- Ensure deep-link/widget/custom intent duration paths call the same duration normalization.
+- Add unit tests for valid, missing, and invalid intent durations where possible.
+
+## Testing Plan
+
+### Unit Tests
+- Duration formatter covers 1, 5, 59, 60, 75, 90, 120, and 150 minutes.
+- Parser rejects empty, non-numeric, zero, and negative values while accepting values over 120.
+- Intent validation accepts nil and any positive whole-minute duration, including values over 120, and rejects non-positive values.
+- TimerViewModel custom target selection clears preset state and vice versa.
+
+### UI Tests
+- Default tap Start still starts immediately.
+- Long-press Start opens `custom_duration_sheet`.
+- Slider and text field remain synchronized.
+- Applying a custom start duration opens the running timer with the custom target selected.
+- Running-screen bottom-right chip opens the sheet.
+- Tapping the active custom chip again clears the custom target and returns the timer to the untimed visual state.
+
+### Device-Only Checks
+- Local notification fires for a custom duration.
+- Live Activity reflects custom progress and completion.
+- Shortcuts/Siri invocation with a duration foregrounds the app and starts the correctly timed session.
+
+## Open Questions
+
+1. Should the app remember the last custom duration as the sheet default? Recommendation: yes, store only the last minute value locally, not session history metadata.
+2. Which preset should be removed to reserve the last grid slot for Custom? Decision: remove the 1-minute preset and keep 5, 10, 15, 20, 30, 45, and 60 minutes plus Custom.
+3. Should applying a custom duration while running schedule the bell relative to session start or from the current moment? Recommendation: relative to session start, matching current preset semantics. If the chosen duration has already elapsed, show an inline warning and require a future duration.
+4. Should invalid Shortcut durations clamp or fail? Recommendation: fail for non-positive values with a clear message, because silent clamping could surprise automation users. Do not clamp valid positive durations down to 120 minutes.


### PR DESCRIPTION
### Motivation

- Provide a discoverable, validated way for users to set arbitrary whole-minute meditation durations beyond the preset chips. 
- Keep the fast tap-to-start flow while allowing long-press and in-session adjustments to set or clear a custom end target. 
- Centralize duration validation and formatting so deep links, App Intents, Shortcuts, and in-app UI share the same rules.

### Description

- Add a new `MeditationDuration` value type that encapsulates minute/second conversion, formatting, parsing, slider clamping, and validation. 
- Implement a reusable `CustomDurationSheet` SwiftUI view and wire it into `TimerStartView` (long-press Start) and `TimerRunningView` (custom chip) to apply custom durations. 
- Refactor `TimerViewModel` to expose `setDurationTarget(seconds:)`, `setDurationTarget(minutes:)`, and `clearDurationTarget`, remove the temporary-option list manipulation, keep seven preset chips, and schedule timer notifications via `NotificationManager`. 
- Update `BellControlsGrid` to render a custom chip alongside presets and adjust selection behavior, and tighten `MeditationSessionIntent.perform()` to validate durations using `MeditationDuration` before applying.

### Testing

- Added unit tests `MeditationDurationTests`, updated `TimerPresetDurationTests`, and extended `DeepLinkTests` to validate duration parsing, formatting, clamping, and intent acceptance/rejection of non-positive values. 
- Updated UI tests in `TimerFlowUITests` and `TimerDeepLinkUITests` to exercise the custom chip and simulator short-duration flow. 
- Ran the project's unit test suite and updated UI tests in CI; all added and modified automated tests passed. 
- Manual assertions in view controllers and notification scheduling code are covered by the new unit tests and simulated flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2821afb6bc83288422046b0a2387b0)