### PR TITLE
fix(timer): cap custom duration slider to 1 hour & lock sheet to medium detent

### DIFF
--- a/LittleMoments/Core/Audio/MeditationDuration.swift
+++ b/LittleMoments/Core/Audio/MeditationDuration.swift
@@ -3,7 +3,7 @@ import Foundation
 struct MeditationDuration: Equatable {
   static let minimumMinutes = 1
   static let sliderMinimumMinutes = 1
-  static let sliderMaximumMinutes = 120
+  static let sliderMaximumMinutes = 60
 
   enum ValidationError: LocalizedError, Equatable {
     case empty

--- a/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
+++ b/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
@@ -65,7 +65,7 @@ struct CustomDurationSheet: View {
     .padding(.horizontal, 24)
     .padding(.top, 20)
     .padding(.bottom, 18)
-    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .background(backgroundSurface)
     .toolbar {
       ToolbarItemGroup(placement: .keyboard) {
@@ -93,7 +93,7 @@ struct CustomDurationSheet: View {
   private var durationEditorSection: some View {
     VStack(alignment: .leading, spacing: 10) {
       durationControlRow
-      Text(validationMessage ?? "Tap the value to type, or use the slider for 1 min–2 hr.")
+      Text(validationMessage ?? "Tap the value to type, or use the slider for 1 min–1 hr.")
         .font(.footnote)
         .foregroundStyle(validationMessage == nil ? Color.secondary : Color.red)
         .fixedSize(horizontal: false, vertical: true)
@@ -128,7 +128,7 @@ struct CustomDurationSheet: View {
         .focused($minutesFieldIsFocused)
         .frame(maxWidth: .infinity, minHeight: 44, maxHeight: 44, alignment: .trailing)
         .accessibilityIdentifier("custom_duration_minutes_field")
-        .accessibilityHint("Enter a duration in minutes; values over 2 hours are allowed.")
+        .accessibilityHint("Enter a duration in minutes; values over 1 hour can be typed.")
         .onChange(of: minutesText) { _, newValue in
           updateDraftMinutes(from: newValue)
         }
@@ -202,7 +202,7 @@ struct CustomDurationSheet: View {
       HStack {
         Text("1 min")
         Spacer()
-        Text("2 hr")
+        Text("1 hr")
       }
       .font(.caption)
       .foregroundStyle(.secondary)
@@ -289,7 +289,7 @@ struct CustomDurationSheet: View {
 
     let shouldProvideFeedback =
       minutes.isMultiple(of: 5)
-      || [30, 60, 120].contains(minutes)
+      || [30, 60].contains(minutes)
     guard shouldProvideFeedback else { return }
 
     UIImpactFeedbackGenerator(style: .light).impactOccurred()

--- a/LittleMoments/Features/Timer/Views/TimerRunningView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerRunningView.swift
@@ -98,7 +98,7 @@ struct TimerRunningView: View {
         onApply: applyCustomDuration,
         onCancel: { showCustomDurationSheet = false }
       )
-      .presentationDetents([.medium, .large])
+      .presentationDetents([.medium])
       .presentationDragIndicator(.visible)
       .presentationCornerRadius(32)
     }

--- a/LittleMoments/Features/Timer/Views/TimerStartView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerStartView.swift
@@ -55,7 +55,7 @@ struct TimerStartView: View {
         onApply: startCustomSession,
         onCancel: { showCustomDurationSheet = false }
       )
-      .presentationDetents([.medium, .large])
+      .presentationDetents([.medium])
       .presentationDragIndicator(.visible)
       .presentationCornerRadius(32)
     }

--- a/LittleMoments/Tests/UnitTests/TimerTests/MeditationDurationTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/MeditationDurationTests.swift
@@ -35,9 +35,9 @@ final class MeditationDurationTests: XCTestCase {
     XCTAssertEqual(duration.minutes, 150)
   }
 
-  func testSliderMinutesClampToOneThroughTwoHours() {
+  func testSliderMinutesClampToOneThroughOneHour() {
     XCTAssertEqual(MeditationDuration.clampedSliderMinutes(-10), 1)
     XCTAssertEqual(MeditationDuration.clampedSliderMinutes(25.4), 25)
-    XCTAssertEqual(MeditationDuration.clampedSliderMinutes(140), 120)
+    XCTAssertEqual(MeditationDuration.clampedSliderMinutes(140), 60)
   }
 }


### PR DESCRIPTION
### Motivation
- The custom-duration slider should target a smaller, more useful range (1 minute → 1 hour) and the sheet UI should occupy the full medium detent vertical space instead of exposing a large/full detent by default.

### Description
- Limit the slider range by changing `MeditationDuration.sliderMaximumMinutes` from `120` to `60` so the slider covers 1 minute–1 hour while typed durations above the slider remain accepted.
- Make `CustomDurationSheet` fill its available vertical space by adding `.frame(maxHeight: .infinity, ...)` and update copy/labels/accessibility to indicate the new `1 min–1 hr` slider range and the end label `"1 hr"`.
- Adjust slider haptic checkpoints to remove the 2‑hour tick and only include `[30, 60]` minutes for feedback.
- Force the custom-duration sheet to the medium detent by replacing `.presentationDetents([.medium, .large])` with `.presentationDetents([.medium])` in both `TimerRunningView` and `TimerStartView`.
- Update the unit test `MeditationDurationTests` to reflect the new clamp behavior (clamping values above slider maximum to `60`).

### Testing
- Ran `swift-format format -i` on the modified files, which completed successfully.
- Ran `git diff --check` to verify there are no trailing whitespace/patch issues, which reported no problems.
- Could not run repo Fastlane lanes (`bin/fastlane generate`, `bin/fastlane format_code`, `bin/fastlane lint`, `bin/fastlane test`) because the environment is missing the bundled Fastlane gems and `bundle install` failed with Rubygems HTTP 403 responses, so unit/UI tests were not executed here.
- The relevant unit test file `LittleMoments/Tests/UnitTests/TimerTests/MeditationDurationTests.swift` was updated to assert the new clamping behavior (140 -> 60) but the tests were not run due to the Fastlane/bundler issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b74c3a2f48328995bf08d8ab33068)