### PR TITLE
fix(live-activity): simplify lock screen progress

### DIFF
--- a/LittleMoments/WidgetExtension/MeditationLiveActivityView.swift
+++ b/LittleMoments/WidgetExtension/MeditationLiveActivityView.swift
@@ -7,6 +7,8 @@ struct MeditationLiveActivityView: View {
   let context: ActivityViewContext<MeditationLiveActivityAttributes>
   @Environment(\.showsWidgetContainerBackground) var showsWidgetBackground
 
+  private let horizontalPadding: CGFloat = 16
+
   @ViewBuilder
   var body: some View {
     let reducesTransparency = UIAccessibility.isReduceTransparencyEnabled
@@ -22,7 +24,7 @@ struct MeditationLiveActivityView: View {
     )
     let fillStyle: AnyShapeStyle = showsWidgetBackground ? AnyShapeStyle(Color.clear) : baseFill
 
-    let content = ZStack {
+    let content = ZStack(alignment: .bottom) {
       ContainerRelativeShape()
         .fill(fillStyle)
         .overlay {
@@ -31,44 +33,48 @@ struct MeditationLiveActivityView: View {
           }
         }
 
-      VStack {
-        Text("Meditation in progress")
-          .font(.headline)
+      VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(context.state.isCompleted ? "Meditation complete" : "Meditating")
+            .font(.caption2.weight(.semibold))
+            .tracking(1)
+            .textCase(.uppercase)
+            .foregroundStyle(.secondary)
 
-        HStack(spacing: 16) {
-          // Timer display
-          VStack {
-            LiveActivityElapsedTimeView(state: context.state)
-              .font(.system(size: 28, weight: .bold, design: .rounded))
-              .monospacedDigit()
-              .minimumScaleFactor(0.5)
-          }
-
-          // Progress bar (for timed sessions)
-          if context.state.targetTimeInSeconds != nil {
-            LiveActivityProgressView(state: context.state)
-              .progressViewStyle(.circular)
-              .frame(width: 40, height: 40)
-          }
+          LiveActivityElapsedTimeView(state: context.state)
+            .font(.system(size: 44, weight: .bold, design: .rounded))
+            .monospacedDigit()
+            .minimumScaleFactor(0.7)
+            .lineLimit(1)
+            .contentTransition(.numericText())
         }
-        .padding(.vertical, 4)
 
-        // Use links instead of buttons for deep linking
-        HStack(spacing: 12) {
+        HStack(spacing: 10) {
           if let url = URL(string: "littlemoments://cancelSession") {
             Link(destination: url) {
-              glassLinkLabel("Cancel", role: .destructive, reducesTransparency: reducesTransparency)
+              glassLinkLabel("Cancel", role: .neutral, reducesTransparency: reducesTransparency)
             }
           }
 
           if let url = URL(string: "littlemoments://finishSession") {
             Link(destination: url) {
-              glassLinkLabel("Finish", role: .success, reducesTransparency: reducesTransparency)
+              glassLinkLabel("Finish", role: .accent, reducesTransparency: reducesTransparency)
             }
           }
         }
       }
-      .padding()
+      .padding(.horizontal, horizontalPadding)
+      .padding(.top, 14)
+      .padding(.bottom, 12)
+
+      if context.state.targetTimeInSeconds != nil {
+        LiveActivityProgressView(state: context.state)
+          .progressViewStyle(.linear)
+          .tint(context.state.isCompleted ? LiquidGlassTokens.successTint : .accentColor)
+          .frame(maxWidth: .infinity)
+          .padding(.horizontal, 1)
+          .accessibilityLabel("Session progress")
+      }
     }
 
     content
@@ -92,8 +98,36 @@ struct LiveActivityElapsedTimeView: View {
     } else if state.showSeconds {
       Text(state.startDate, style: .timer)
     } else {
-      Text(state.startDate, style: .relative)
+      Text(
+        TimeDataSource<Duration>.durationOffset(to: state.startDate),
+        format: ElapsedMinutesFormatStyle()
+      )
     }
+  }
+}
+
+private struct ElapsedMinutesFormatStyle: DiscreteFormatStyle {
+  private var schedule: Duration.UnitsFormatStyle {
+    Duration.UnitsFormatStyle(
+      allowedUnits: [.minutes],
+      width: .narrow,
+      maximumUnitCount: 1,
+      zeroValueUnits: .show(length: 1),
+      fractionalPart: .hide(rounded: .towardZero)
+    )
+  }
+
+  func format(_ value: Duration) -> String {
+    let elapsed = value < .zero ? .zero - value : value
+    return String(elapsed.components.seconds / 60)
+  }
+
+  func discreteInput(before input: Duration) -> Duration? {
+    schedule.discreteInput(before: input)
+  }
+
+  func discreteInput(after input: Duration) -> Duration? {
+    schedule.discreteInput(after: input)
   }
 }
 
@@ -104,13 +138,16 @@ struct LiveActivityProgressView: View {
   var body: some View {
     if state.isCompleted, let targetTime = state.targetTimeInSeconds, targetTime > 0 {
       ProgressView(value: min(state.secondsElapsed / targetTime, 1.0))
+        .labelsHidden()
     } else if let targetEndDate = state.targetEndDate, targetEndDate > state.startDate {
       ProgressView(
         timerInterval: state.startDate...targetEndDate,
         countsDown: false
       )
+      .labelsHidden()
     } else {
       ProgressView(value: 0)
+        .labelsHidden()
     }
   }
 }
@@ -148,8 +185,8 @@ extension MeditationLiveActivityView {
         .font(.system(.subheadline, design: .rounded).weight(.semibold))
         .foregroundStyle(role.foregroundColor(for: .prominent))
         .padding(.horizontal, 6)
-        .padding(.vertical, 8)
+        .padding(.vertical, 6)
     }
-    .frame(maxWidth: .infinity, minHeight: 38)
+    .frame(maxWidth: .infinity, minHeight: 34)
   }
 }

--- a/LittleMoments/WidgetExtension/WidgetBundle.swift
+++ b/LittleMoments/WidgetExtension/WidgetBundle.swift
@@ -86,109 +86,60 @@ struct MeditationLiveActivityWidget: Widget {
 #if DEBUG
   // MARK: - Live Activity Previews
 
-  // Shared preview view that uses the same logic as the real widget
-  struct LiveActivityPreviewView: View {
-    let state: MeditationLiveActivityAttributes.ContentState
-    let attributes: MeditationLiveActivityAttributes
-    @Environment(\.showsWidgetContainerBackground) var showsWidgetBackground
-
-    var body: some View {
-      ZStack {
-        ContainerRelativeShape()
-          .fill(showsWidgetBackground ? .clear : .black.opacity(0.1))
-
-        VStack {
-          Text("Meditation in progress")
-            .font(.headline)
-
-          HStack(spacing: 16) {
-            // Timer display using shared logic
-            VStack {
-              Text(
-                timerDisplayFromSeconds(
-                  seconds: state.secondsElapsed, showSeconds: state.showSeconds)
-              )
-              .font(.system(size: 28, weight: .bold, design: .rounded))
-              .monospacedDigit()
-              .minimumScaleFactor(0.5)
-            }
-
-            // Progress bar (for timed sessions)
-            if let targetTime = state.targetTimeInSeconds, targetTime > 0 {
-              ProgressView(value: min(state.secondsElapsed / targetTime, 1.0))
-                .progressViewStyle(.circular)
-                .frame(width: 40, height: 40)
-            }
-          }
-          .padding(.vertical, 4)
-
-          // Use links instead of buttons for deep linking
-          HStack(spacing: 12) {
-            if let url = URL(string: "littlemoments://cancelSession") {
-              Link(destination: url) {
-                Text("Cancel")
-                  .frame(maxWidth: .infinity)
-                  .padding(.vertical, 6)
-                  .background(Color.red.opacity(0.2))
-                  .cornerRadius(8)
-                  .foregroundColor(.red)
-              }
-            }
-
-            if let url = URL(string: "littlemoments://finishSession") {
-              Link(destination: url) {
-                Text("Finish")
-                  .frame(maxWidth: .infinity)
-                  .padding(.vertical, 6)
-                  .background(Color.green.opacity(0.2))
-                  .cornerRadius(8)
-                  .foregroundColor(.green)
-              }
-            }
-          }
-        }
-        .padding()
-      }
-    }
+  private var previewStateWithoutSeconds: MeditationLiveActivityAttributes.ContentState {
+    MeditationLiveActivityAttributes.ContentState(
+      secondsElapsed: 185,
+      targetTimeInSeconds: 600,
+      isCompleted: false,
+      showSeconds: false
+    )
   }
 
-  // Standard preview provider using shared logic
-  struct LiveActivityPreviews: PreviewProvider {
-    static var previews: some View {
-      Group {
-        // Preview in-progress with system background
-        LiveActivityPreviewView(
-          state: MeditationLiveActivityAttributes.previewState,
-          attributes: MeditationLiveActivityAttributes.preview
-        )
-        .containerBackground(for: .widget) {
-          Color(.systemBackground)
-        }
-        .previewDisplayName("Light Mode")
-        .previewContext(WidgetPreviewContext(family: .systemMedium))
+  private var previewStateUntimed: MeditationLiveActivityAttributes.ContentState {
+    MeditationLiveActivityAttributes.ContentState(
+      secondsElapsed: 185,
+      isCompleted: false,
+      showSeconds: true
+    )
+  }
 
-        // Preview with dark background
-        LiveActivityPreviewView(
-          state: MeditationLiveActivityAttributes.previewState,
-          attributes: MeditationLiveActivityAttributes.preview
-        )
-        .containerBackground(for: .widget) {
-          Color.black
-        }
-        .previewDisplayName("Dark Mode")
-        .previewContext(WidgetPreviewContext(family: .systemMedium))
+  #Preview(
+    "Lock Screen · Seconds",
+    as: .content,
+    using: MeditationLiveActivityAttributes.preview
+  ) {
+    MeditationLiveActivityWidget()
+  } contentStates: {
+    MeditationLiveActivityAttributes.previewState
+  }
 
-        // Preview completed
-        LiveActivityPreviewView(
-          state: MeditationLiveActivityAttributes.previewStateCompleted,
-          attributes: MeditationLiveActivityAttributes.preview
-        )
-        .containerBackground(for: .widget) {
-          Color(.systemBackground)
-        }
-        .previewDisplayName("Completed")
-        .previewContext(WidgetPreviewContext(family: .systemMedium))
-      }
-    }
+  #Preview(
+    "Lock Screen · Minutes",
+    as: .content,
+    using: MeditationLiveActivityAttributes.preview
+  ) {
+    MeditationLiveActivityWidget()
+  } contentStates: {
+    previewStateWithoutSeconds
+  }
+
+  #Preview(
+    "Lock Screen · Untimed",
+    as: .content,
+    using: MeditationLiveActivityAttributes.preview
+  ) {
+    MeditationLiveActivityWidget()
+  } contentStates: {
+    previewStateUntimed
+  }
+
+  #Preview(
+    "Lock Screen · Complete",
+    as: .content,
+    using: MeditationLiveActivityAttributes.preview
+  ) {
+    MeditationLiveActivityWidget()
+  } contentStates: {
+    MeditationLiveActivityAttributes.previewStateCompleted
   }
 #endif


### PR DESCRIPTION
## Summary

- replace the cramped circular Lock Screen progress indicator with a thin linear edge gauge
- promote elapsed time to a single clear foreground value and hide the progress control’s automatic time label
- respect the Show seconds preference with system-driven second or minute updates
- replace the hand-built preview imitation with production `ActivityConfiguration` previews for seconds, minutes, untimed, and completed states

## Root cause

The Lock Screen view rendered elapsed time separately while a timer-backed circular `ProgressView` also supplied its own current-value label. In the constrained Live Activity card, that produced duplicate time text and overlap inside the progress ring. The progress label also bypassed the user’s Show seconds preference.

## Impact

The Live Activity is easier to scan, preserves date-driven background refreshes, and presents exactly one elapsed-time value. Untimed sessions omit progress, while timed sessions use a subtle full-width linear indicator.

## Validation

- `bin/fastlane format_code` on both changed files
- `bin/fastlane lint` on both changed files
- `bin/fastlane build`
- 111 `LittleMomentsTests` passed on iPhone 17 Pro simulator
- visual Lock Screen QA with Show seconds disabled and timed progress active

Planning docs are unchanged because this is a presentation and preference-adherence fix with no product behavior change.