### PR TITLE
fix(timer): base finish preview on session start

### DIFF
--- a/LittleMoments/Features/Timer/Models/TimerViewModel.swift
+++ b/LittleMoments/Features/Timer/Models/TimerViewModel.swift
@@ -29,6 +29,7 @@ class TimerViewModel: ObservableObject {
 
   // Running timer
   private var startDate: Date?
+  var sessionStartDate: Date? { startDate }
   var timer: Timer?
   var timeElapsedFormatted: String {
     return getTimeElapsedFormatted()

--- a/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
+++ b/LittleMoments/Features/Timer/Views/CustomDurationSheet.swift
@@ -24,10 +24,27 @@ enum CustomDurationSheetMode: Equatable {
       return "Set bell for \(duration.shortLabel)"
     }
   }
+
+  func projectedFinishDate(
+    duration: TimeInterval,
+    now: Date,
+    sessionStartDate: Date?
+  ) -> Date {
+    let referenceDate: Date
+    switch self {
+    case .start:
+      referenceDate = now
+    case .running:
+      referenceDate = sessionStartDate ?? now
+    }
+
+    return referenceDate.addingTimeInterval(duration)
+  }
 }
 
 struct CustomDurationSheet: View {
   let mode: CustomDurationSheetMode
+  let sessionStartDate: Date?
   let onApply: (MeditationDuration) -> Void
   let onCancel: () -> Void
 
@@ -41,10 +58,12 @@ struct CustomDurationSheet: View {
   init(
     mode: CustomDurationSheetMode,
     initialMinutes: Int,
+    sessionStartDate: Date? = nil,
     onApply: @escaping (MeditationDuration) -> Void,
     onCancel: @escaping () -> Void
   ) {
     self.mode = mode
+    self.sessionStartDate = sessionStartDate
     self.onApply = onApply
     self.onCancel = onCancel
     _draftMinutes = State(initialValue: max(initialMinutes, MeditationDuration.minimumMinutes))
@@ -257,7 +276,11 @@ struct CustomDurationSheet: View {
   )
 
   private func projectedFinishTime(from now: Date) -> String {
-    let finishDate = now.addingTimeInterval(TimeInterval(currentDuration.seconds))
+    let finishDate = mode.projectedFinishDate(
+      duration: TimeInterval(currentDuration.seconds),
+      now: now,
+      sessionStartDate: sessionStartDate
+    )
     return Self.finishTimeFormatter.string(from: finishDate)
   }
 

--- a/LittleMoments/Features/Timer/Views/TimerRunningView.swift
+++ b/LittleMoments/Features/Timer/Views/TimerRunningView.swift
@@ -76,6 +76,7 @@ struct TimerRunningView: View {
       CustomDurationSheet(
         mode: .running,
         initialMinutes: customDurationInitialMinutes,
+        sessionStartDate: timerViewModel.sessionStartDate,
         onApply: applyCustomDuration,
         onCancel: { showCustomDurationSheet = false }
       )

--- a/LittleMoments/Tests/UnitTests/TimerTests/CustomDurationSheetTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/CustomDurationSheetTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+@preconcurrency import XCTest
+
+@testable import LittleMoments
+
+final class CustomDurationSheetTests: XCTestCase {
+  func testStartModeProjectsFinishFromCurrentTime() {
+    let now = Date(timeIntervalSinceReferenceDate: 10_000)
+    let earlierSessionStart = now.addingTimeInterval(-300)
+
+    let finishDate = CustomDurationSheetMode.start.projectedFinishDate(
+      duration: 600,
+      now: now,
+      sessionStartDate: earlierSessionStart
+    )
+
+    XCTAssertEqual(finishDate, now.addingTimeInterval(600))
+  }
+
+  func testRunningModeProjectsFinishFromSessionStart() {
+    let now = Date(timeIntervalSinceReferenceDate: 10_000)
+    let sessionStart = now.addingTimeInterval(-300)
+
+    let finishDate = CustomDurationSheetMode.running.projectedFinishDate(
+      duration: 600,
+      now: now,
+      sessionStartDate: sessionStart
+    )
+
+    XCTAssertEqual(finishDate, sessionStart.addingTimeInterval(600))
+    XCTAssertEqual(finishDate.timeIntervalSince(now), 300)
+  }
+
+  func testRunningModeFallsBackToCurrentTimeWithoutSessionStart() {
+    let now = Date(timeIntervalSinceReferenceDate: 10_000)
+
+    let finishDate = CustomDurationSheetMode.running.projectedFinishDate(
+      duration: 600,
+      now: now,
+      sessionStartDate: nil
+    )
+
+    XCTAssertEqual(finishDate, now.addingTimeInterval(600))
+  }
+}


### PR DESCRIPTION
## Summary

- base the running custom-duration finish preview on the active session's start time
- preserve current-time projection when configuring a duration before starting
- add regression tests for both modes and the missing-start fallback

## Root cause

The custom-duration sheet always added the selected duration to the current time. Timer targets are measured from session start, so the preview drifted later by however long the session had already been running.

## User impact

When adjusting an already-running session, “Ends around” now matches the bell target. For example, changing a session five minutes in to a ten-minute duration previews a finish five minutes from now.

## Validation

- `bin/fastlane lint` on all changed files
- `bin/fastlane test_unit` — 115 tests passed
- `git diff --check`
