### PR TITLE
Change bell strategy to make foreground bell more reliable

### DIFF
--- a/LittleMoments/Core/Audio/BellPlaybackCoordinator.swift
+++ b/LittleMoments/Core/Audio/BellPlaybackCoordinator.swift
@@ -7,6 +7,7 @@
 
 import AVFoundation
 import Foundation
+import UIKit
 
 enum BellPlaybackMode: String, CaseIterable {
   case off
@@ -97,6 +98,7 @@ protocol BellPlaybackCoordinating: AnyObject {
 
   func startSession(startDate: Date, ringBellAtStart: Bool)
   func setTarget(secondsFromSessionStart: Int?, elapsedSeconds: TimeInterval)
+  func ensureCompletionBellAudible(elapsedSeconds: TimeInterval)
   func finishSession()
   func cancelSession()
 }
@@ -116,27 +118,49 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
   static let shared = BellPlaybackCoordinator()
 
   private static let silentLoopDurationSeconds: Double = 60
+  private static let foregroundFallbackGraceSeconds: TimeInterval = 0.5
+  private static let minimumConfirmedBellProgressSeconds: TimeInterval = 0.05
+  private static let maximumForegroundFallbackDelaySeconds: TimeInterval = 5
 
   private var sessionStartDate: Date?
-  private var targetPlanID = UUID()
+  private var watchdogState = CompletionBellWatchdogState()
+  private var targetSecondsFromSessionStart: Int?
   private var completionTask: Task<Void, Never>?
+  private var fallbackWatchdogTask: Task<Void, Never>?
   private var queuePlayer: AVQueuePlayer?
   private var playerLooper: AVPlayerLooper?
+  private var completionBellItem: AVPlayerItem?
+  private var completionBellPlanID: UUID?
+  private var completionBellAttemptDate: Date?
   private var completionObserver: NSObjectProtocol?
   private var cachedSilentAudioURL: URL?
   private var isAudioSessionActive = false
+
+  private let applicationIsActive: @MainActor () -> Bool
+  private let foregroundBellPlayer: @MainActor () -> Bool
+
+  init(
+    applicationIsActive: @escaping @MainActor () -> Bool = {
+      UIApplication.shared.connectedScenes.contains {
+        $0.activationState == .foregroundActive
+      }
+    },
+    foregroundBellPlayer: @escaping @MainActor () -> Bool = {
+      SoundManager.playSound()
+    }
+  ) {
+    self.applicationIsActive = applicationIsActive
+    self.foregroundBellPlayer = foregroundBellPlayer
+  }
 
   var mode: BellPlaybackMode {
     BellPlaybackMode.resolved()
   }
 
-  var shouldSuppressForegroundTimerBell: Bool {
-    mode.usesAudioPlayback
-  }
-
   func startSession(startDate: Date, ringBellAtStart: Bool) {
     sessionStartDate = startDate
-    targetPlanID = UUID()
+    _ = watchdogState.replacePlan()
+    targetSecondsFromSessionStart = nil
     BellPlaybackDiagnostics.sessionStarted(
       startDate: startDate,
       mode: mode,
@@ -152,11 +176,13 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
       elapsedSeconds: elapsedSeconds
     )
 
-    targetPlanID = UUID()
+    let planID = watchdogState.replacePlan()
+    targetSecondsFromSessionStart = secondsFromSessionStart
+    clearCompletionBellState()
 
     guard mode.usesAudioPlayback else {
       BellPlaybackDiagnostics.notificationSkipped(reason: "mode_does_not_use_audio", mode: mode)
-      stopPlayback(deactivateSession: true)
+      stopPlayback(deactivateSession: true, invalidatePlan: false)
       return
     }
 
@@ -168,12 +194,11 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     let remainingSeconds = TimeInterval(secondsFromSessionStart) - elapsedSeconds
     guard remainingSeconds > 0 else {
       BellPlaybackDiagnostics.completionPlanCancelled(
-        planID: targetPlanID, reason: "target_elapsed")
+        planID: planID, reason: "target_elapsed")
       stopPlayback(deactivateSession: true)
       return
     }
 
-    let planID = targetPlanID
     guard startPlaybackPlan() else { return }
 
     BellPlaybackDiagnostics.completionPlanScheduled(
@@ -187,10 +212,12 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
 
   private func cancelCompletionTask(reason: String) {
     if completionTask != nil {
-      BellPlaybackDiagnostics.completionPlanCancelled(planID: targetPlanID, reason: reason)
+      BellPlaybackDiagnostics.completionPlanCancelled(planID: watchdogState.planID, reason: reason)
     }
     completionTask?.cancel()
     completionTask = nil
+    fallbackWatchdogTask?.cancel()
+    fallbackWatchdogTask = nil
   }
 
   private func startPlaybackPlan() -> Bool {
@@ -201,7 +228,7 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     } catch {
       BellPlaybackDiagnostics.audioSessionActivationFailed(error)
       print("Failed to start robust bell silence loop: \(error.localizedDescription)")
-      stopPlayback(deactivateSession: true)
+      stopPlayback(deactivateSession: true, invalidatePlan: false)
       return false
     }
   }
@@ -212,11 +239,48 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
       try? await Task.sleep(nanoseconds: nanoseconds)
 
       await MainActor.run {
-        guard let self, !Task.isCancelled, self.targetPlanID == planID else { return }
+        guard let self, !Task.isCancelled, self.watchdogState.planID == planID else {
+          BellPlaybackDiagnostics.foregroundFallbackSkipped(reason: "stale_plan")
+          return
+        }
         BellPlaybackDiagnostics.completionPlanFired(planID: planID)
-        self.playCompletionBell()
+        self.playCompletionBell(planID: planID)
       }
     }
+  }
+
+  func ensureCompletionBellAudible(elapsedSeconds: TimeInterval) {
+    guard
+      let targetSecondsFromSessionStart,
+      elapsedSeconds >= TimeInterval(targetSecondsFromSessionStart),
+      elapsedSeconds - TimeInterval(targetSecondsFromSessionStart)
+        <= Self.maximumForegroundFallbackDelaySeconds
+    else { return }
+
+    let planID = watchdogState.planID
+    guard mode.usesAudioPlayback else {
+      startForegroundFallbackIfNeeded(planID: planID, progressSeconds: nil)
+      return
+    }
+
+    if completionBellPlanID == planID, let completionBellItem {
+      guard
+        let completionBellAttemptDate,
+        Date().timeIntervalSince(completionBellAttemptDate)
+          >= Self.foregroundFallbackGraceSeconds
+      else { return }
+
+      evaluateForegroundFallback(
+        planID: planID,
+        player: queuePlayer,
+        item: completionBellItem
+      )
+      return
+    }
+
+    completionTask?.cancel()
+    completionTask = nil
+    playCompletionBell(planID: planID)
   }
 
   func finishSession() {
@@ -254,24 +318,30 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     BellPlaybackDiagnostics.silentLoopStarted(url: silentAudioURL)
   }
 
-  private func playCompletionBell() {
+  private func playCompletionBell(planID: UUID) {
+    guard watchdogState.planID == planID else {
+      BellPlaybackDiagnostics.foregroundFallbackSkipped(reason: "stale_plan")
+      return
+    }
+
     completionTask?.cancel()
     completionTask = nil
-    targetPlanID = UUID()
     playerLooper?.disableLooping()
     playerLooper = nil
 
     guard let soundURL = SoundManager.soundURL else {
       BellPlaybackDiagnostics.finalBellMissingSound()
       print("Could not find bell sound file for robust playback")
-      stopPlayback(deactivateSession: true)
+      stopPlayback(deactivateSession: true, invalidatePlan: false)
+      startForegroundFallbackIfNeeded(planID: planID, progressSeconds: nil)
       return
     }
 
     guard let queuePlayer else {
       BellPlaybackDiagnostics.finalBellQueueUnavailable()
       print("Could not play robust completion bell because the audio queue was unavailable")
-      stopPlayback(deactivateSession: true)
+      stopPlayback(deactivateSession: true, invalidatePlan: false)
+      startForegroundFallbackIfNeeded(planID: planID, progressSeconds: nil)
       return
     }
 
@@ -279,18 +349,22 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     guard Self.replaceQueueContents(with: bellItem, in: queuePlayer) else {
       BellPlaybackDiagnostics.finalBellQueueTransitionFailed()
       print("Could not insert robust completion bell into the active audio queue")
-      stopPlayback(deactivateSession: true)
+      stopPlayback(deactivateSession: true, invalidatePlan: false)
+      startForegroundFallbackIfNeeded(planID: planID, progressSeconds: nil)
       return
     }
 
-    observeCompletion(of: bellItem)
+    completionBellItem = bellItem
+    completionBellPlanID = planID
+    completionBellAttemptDate = Date()
+    observeCompletion(of: bellItem, planID: planID)
     queuePlayer.play()
     BellPlaybackDiagnostics.finalBellStarted(
       playerStatus: queuePlayer.status,
       timeControlStatus: queuePlayer.timeControlStatus,
       itemStatus: bellItem.status
     )
-    scheduleFinalBellProgressCheck(player: queuePlayer, item: bellItem)
+    scheduleForegroundFallbackWatchdog(planID: planID, player: queuePlayer, item: bellItem)
   }
 
   @discardableResult
@@ -304,24 +378,42 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     return true
   }
 
-  private func scheduleFinalBellProgressCheck(
+  private func scheduleForegroundFallbackWatchdog(
+    planID: UUID,
     player: AVQueuePlayer,
     item: AVPlayerItem
   ) {
-    Task { [weak self, weak player, weak item] in
-      try? await Task.sleep(for: .seconds(1))
+    fallbackWatchdogTask?.cancel()
+    fallbackWatchdogTask = Task { [weak self, weak player, weak item] in
+      try? await Task.sleep(for: .seconds(Self.foregroundFallbackGraceSeconds))
 
       guard
+        !Task.isCancelled,
         let self,
         let player,
-        let item,
-        self.queuePlayer === player,
-        player.currentItem === item
+        let item
       else { return }
 
+      self.evaluateForegroundFallback(planID: planID, player: player, item: item)
+    }
+  }
+
+  private func evaluateForegroundFallback(
+    planID: UUID,
+    player: AVQueuePlayer?,
+    item: AVPlayerItem
+  ) {
+    let progressSeconds: TimeInterval?
+    if let player,
+      queuePlayer === player,
+      player.currentItem === item,
+      completionBellItem === item,
+      completionBellPlanID == planID
+    {
+      progressSeconds = player.currentTime().seconds
       BellPlaybackDiagnostics.finalBellProgressChecked(
         BellPlaybackDiagnostics.FinalBellPlaybackState(
-          elapsedSeconds: player.currentTime().seconds,
+          elapsedSeconds: progressSeconds ?? .nan,
           playerStatus: player.status.rawValue,
           timeControlStatus: player.timeControlStatus.rawValue,
           itemStatus: item.status.rawValue,
@@ -330,10 +422,45 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
           itemError: item.error?.localizedDescription
         )
       )
+    } else {
+      progressSeconds = nil
     }
+
+    startForegroundFallbackIfNeeded(planID: planID, progressSeconds: progressSeconds)
   }
 
-  private func observeCompletion(of item: AVPlayerItem) {
+  private func startForegroundFallbackIfNeeded(
+    planID: UUID,
+    progressSeconds: TimeInterval?
+  ) {
+    let isActive = applicationIsActive()
+    guard
+      watchdogState.claimFallback(
+        planID: planID,
+        progressSeconds: progressSeconds,
+        minimumConfirmedProgressSeconds: Self.minimumConfirmedBellProgressSeconds,
+        applicationIsActive: isActive
+      )
+    else {
+      let reason: String
+      if planID != watchdogState.planID {
+        reason = "stale_plan"
+      } else if !isActive {
+        reason = "application_inactive"
+      } else if watchdogState.fallbackPlanID == planID {
+        reason = "already_started"
+      } else {
+        reason = "primary_progress_confirmed"
+      }
+      BellPlaybackDiagnostics.foregroundFallbackSkipped(reason: reason)
+      return
+    }
+
+    let didStart = foregroundBellPlayer()
+    BellPlaybackDiagnostics.foregroundFallbackStarted(didStart: didStart)
+  }
+
+  private func observeCompletion(of item: AVPlayerItem, planID: UUID) {
     if let completionObserver {
       NotificationCenter.default.removeObserver(completionObserver)
     }
@@ -345,17 +472,25 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     ) { [weak self] _ in
       Task { @MainActor in
         BellPlaybackDiagnostics.finalBellEnded()
-        self?.stopPlayback(deactivateSession: true)
+        guard let self else { return }
+        let foregroundFallbackIsPlaying = self.watchdogState.fallbackPlanID == planID
+        self.stopPlayback(deactivateSession: !foregroundFallbackIsPlaying)
       }
     }
   }
 
-  private func stopPlayback(deactivateSession: Bool) {
+  private func stopPlayback(deactivateSession: Bool, invalidatePlan: Bool = true) {
     let hadTask = completionTask != nil
     let hadPlayer = queuePlayer != nil
     completionTask?.cancel()
     completionTask = nil
-    targetPlanID = UUID()
+    fallbackWatchdogTask?.cancel()
+    fallbackWatchdogTask = nil
+    if invalidatePlan {
+      _ = watchdogState.replacePlan()
+      targetSecondsFromSessionStart = nil
+    }
+    clearCompletionBellState()
     playerLooper = nil
     queuePlayer?.pause()
     queuePlayer?.removeAllItems()
@@ -382,6 +517,12 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
         print("Failed to deactivate robust bell audio session: \(error.localizedDescription)")
       }
     }
+  }
+
+  private func clearCompletionBellState() {
+    completionBellItem = nil
+    completionBellPlanID = nil
+    completionBellAttemptDate = nil
   }
 
   private func silentAudioURL() throws -> URL {
@@ -420,5 +561,38 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     cachedSilentAudioURL = url
     BellPlaybackDiagnostics.silentAudioCreated(url: url)
     return url
+  }
+}
+
+struct CompletionBellWatchdogState {
+  private(set) var planID = UUID()
+  private(set) var fallbackPlanID: UUID?
+
+  @discardableResult
+  mutating func replacePlan() -> UUID {
+    planID = UUID()
+    fallbackPlanID = nil
+    return planID
+  }
+
+  mutating func claimFallback(
+    planID candidatePlanID: UUID,
+    progressSeconds: TimeInterval?,
+    minimumConfirmedProgressSeconds: TimeInterval,
+    applicationIsActive: Bool
+  ) -> Bool {
+    guard candidatePlanID == planID else { return false }
+    guard applicationIsActive else { return false }
+    guard fallbackPlanID != candidatePlanID else { return false }
+
+    if let progressSeconds,
+      progressSeconds.isFinite,
+      progressSeconds >= minimumConfirmedProgressSeconds
+    {
+      return false
+    }
+
+    fallbackPlanID = candidatePlanID
+    return true
   }
 }

--- a/LittleMoments/Core/Audio/BellPlaybackCoordinator.swift
+++ b/LittleMoments/Core/Audio/BellPlaybackCoordinator.swift
@@ -138,6 +138,7 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
 
   private let applicationIsActive: @MainActor () -> Bool
   private let foregroundBellPlayer: @MainActor () -> Bool
+  private let foregroundBellIsPlaying: @MainActor () -> Bool
 
   init(
     applicationIsActive: @escaping @MainActor () -> Bool = {
@@ -147,10 +148,14 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     },
     foregroundBellPlayer: @escaping @MainActor () -> Bool = {
       SoundManager.playSound()
+    },
+    foregroundBellIsPlaying: @escaping @MainActor () -> Bool = {
+      SoundManager.isPlaying
     }
   ) {
     self.applicationIsActive = applicationIsActive
     self.foregroundBellPlayer = foregroundBellPlayer
+    self.foregroundBellIsPlaying = foregroundBellIsPlaying
   }
 
   var mode: BellPlaybackMode {
@@ -463,6 +468,7 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
     }
 
     let didStart = foregroundBellPlayer()
+    watchdogState.recordFallbackPlaybackStart(planID: planID, didStart: didStart)
     BellPlaybackDiagnostics.foregroundFallbackStarted(didStart: didStart)
   }
 
@@ -479,7 +485,9 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
       Task { @MainActor in
         BellPlaybackDiagnostics.finalBellEnded()
         guard let self else { return }
-        let foregroundFallbackIsPlaying = self.watchdogState.fallbackPlanID == planID
+        let foregroundFallbackIsPlaying =
+          self.watchdogState.fallbackPlaybackPlanID == planID
+          && self.foregroundBellIsPlaying()
         self.stopPlayback(deactivateSession: !foregroundFallbackIsPlaying)
       }
     }
@@ -573,11 +581,13 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
 struct CompletionBellWatchdogState {
   private(set) var planID = UUID()
   private(set) var fallbackPlanID: UUID?
+  private(set) var fallbackPlaybackPlanID: UUID?
 
   @discardableResult
   mutating func replacePlan() -> UUID {
     planID = UUID()
     fallbackPlanID = nil
+    fallbackPlaybackPlanID = nil
     return planID
   }
 
@@ -600,5 +610,10 @@ struct CompletionBellWatchdogState {
 
     fallbackPlanID = candidatePlanID
     return true
+  }
+
+  mutating func recordFallbackPlaybackStart(planID candidatePlanID: UUID, didStart: Bool) {
+    guard candidatePlanID == planID, fallbackPlanID == candidatePlanID, didStart else { return }
+    fallbackPlaybackPlanID = candidatePlanID
   }
 }

--- a/LittleMoments/Core/Audio/BellPlaybackCoordinator.swift
+++ b/LittleMoments/Core/Audio/BellPlaybackCoordinator.swift
@@ -236,10 +236,16 @@ final class BellPlaybackCoordinator: BellPlaybackCoordinating {
   private func scheduleCompletionBell(planID: UUID, remainingSeconds: TimeInterval) {
     completionTask = Task { [weak self] in
       let nanoseconds = UInt64(max(0, remainingSeconds) * 1_000_000_000)
-      try? await Task.sleep(nanoseconds: nanoseconds)
+      do {
+        try await Task.sleep(nanoseconds: nanoseconds)
+      } catch {
+        return
+      }
+      guard !Task.isCancelled else { return }
 
       await MainActor.run {
-        guard let self, !Task.isCancelled, self.watchdogState.planID == planID else {
+        guard let self else { return }
+        guard self.watchdogState.planID == planID else {
           BellPlaybackDiagnostics.foregroundFallbackSkipped(reason: "stale_plan")
           return
         }

--- a/LittleMoments/Core/Audio/BellPlaybackDiagnostics.swift
+++ b/LittleMoments/Core/Audio/BellPlaybackDiagnostics.swift
@@ -136,8 +136,12 @@ enum BellPlaybackDiagnostics {
       logger.error("final_bell_queue_transition_failed")
     }
 
-    static func foregroundBellSuppressed() {
-      logger.info("foreground_bell_suppressed")
+    static func foregroundFallbackStarted(didStart: Bool) {
+      logger.info("foreground_fallback_started accepted=\(didStart, privacy: .public)")
+    }
+
+    static func foregroundFallbackSkipped(reason: String) {
+      logger.info("foreground_fallback_skipped reason=\(reason, privacy: .public)")
     }
 
     static func notificationSkipped(reason: String, mode: BellPlaybackMode? = nil) {
@@ -184,7 +188,8 @@ enum BellPlaybackDiagnostics {
     static func finalBellMissingSound() {}
     static func finalBellQueueUnavailable() {}
     static func finalBellQueueTransitionFailed() {}
-    static func foregroundBellSuppressed() {}
+    static func foregroundFallbackStarted(didStart: Bool) {}
+    static func foregroundFallbackSkipped(reason: String) {}
     static func notificationSkipped(reason: String, mode: BellPlaybackMode? = nil) {}
     static func notificationScheduled(remainingSeconds: TimeInterval, mode: BellPlaybackMode) {}
   #endif

--- a/LittleMoments/Core/Audio/ScheduledBellAlert.swift
+++ b/LittleMoments/Core/Audio/ScheduledBellAlert.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Foundation
 
 protocol ScheduledAlert: Equatable {
@@ -6,7 +5,8 @@ protocol ScheduledAlert: Equatable {
   var hasTarget: Bool { get }
 
   func getProgress(secondsElapsed: CGFloat) -> CGFloat
-  func checkTrigger(secondsElapsed: CGFloat)
+  @discardableResult
+  func checkTrigger(secondsElapsed: CGFloat) -> Bool
 }
 
 class OneTimeScheduledBellAlert: ScheduledAlert {
@@ -50,31 +50,15 @@ class OneTimeScheduledBellAlert: ScheduledAlert {
     return secondsElapsed >= targetTimeInSec
   }
 
-  func checkTrigger(secondsElapsed: CGFloat) {
+  @discardableResult
+  func checkTrigger(secondsElapsed: CGFloat) -> Bool {
     if hasTriggered {
-      return
+      return false
     }
     if self.isDone(secondsElapsed: secondsElapsed) {
-      self.doTrigger(secondsElapsed: secondsElapsed)
       hasTriggered = true
+      return true
     }
-  }
-
-  func doTrigger(secondsElapsed: CGFloat) {
-    let maxDelay: CGFloat = 5.0
-    if secondsElapsed - targetTimeInSec > maxDelay {
-      print("Skipping sound due to delay")
-      return
-    }
-    print("Triggered \(name) alert")
-    Task { @MainActor in
-      if BellPlaybackCoordinator.shared.shouldSuppressForegroundTimerBell {
-        BellPlaybackDiagnostics.foregroundBellSuppressed()
-        print("Skipping foreground timer bell because robust bell audio is active")
-        return
-      }
-
-      SoundManager.playSound()
-    }
+    return false
   }
 }

--- a/LittleMoments/Core/Audio/SoundManager.swift
+++ b/LittleMoments/Core/Audio/SoundManager.swift
@@ -16,6 +16,10 @@ final class SoundManager {
     forResource: "42095__fauxpress__bell-meditation", withExtension: "aif")
   static var audioPlayer: AVAudioPlayer?
 
+  static var isPlaying: Bool {
+    audioPlayer?.isPlaying == true
+  }
+
   static func initialize() {
     if audioPlayer != nil {
       return

--- a/LittleMoments/Core/Audio/SoundManager.swift
+++ b/LittleMoments/Core/Audio/SoundManager.swift
@@ -41,14 +41,22 @@ final class SoundManager {
     }
   }
 
-  static func playSound() {
+  @discardableResult
+  static func playSound() -> Bool {
     guard let audioPlayer else {
       print("Audio player not initialized")
-      return
+      return false
     }
-    if !audioPlayer.play() {
+
+    audioPlayer.stop()
+    audioPlayer.currentTime = 0
+    audioPlayer.prepareToPlay()
+
+    let didStart = audioPlayer.play()
+    if !didStart {
       print("Error playing audio")
     }
+    return didStart
   }
 
   static func dispose() {

--- a/LittleMoments/Features/Timer/Models/TimerViewModel.swift
+++ b/LittleMoments/Features/Timer/Models/TimerViewModel.swift
@@ -205,8 +205,16 @@ class TimerViewModel: ObservableObject {
     timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
       Task { @MainActor in
         guard let self else { return }
-        self.scheduledAlert?.checkTrigger(secondsElapsed: self.secondsElapsed)
+        self.checkScheduledAlert(secondsElapsed: self.secondsElapsed)
       }
+    }
+  }
+
+  func checkScheduledAlert(secondsElapsed: CGFloat) {
+    if scheduledAlert?.checkTrigger(secondsElapsed: secondsElapsed) == true {
+      bellPlaybackCoordinator.ensureCompletionBellAudible(
+        elapsedSeconds: TimeInterval(secondsElapsed)
+      )
     }
   }
 

--- a/LittleMoments/Tests/UnitTests/CoreTests/BellPlaybackCoordinatorTests.swift
+++ b/LittleMoments/Tests/UnitTests/CoreTests/BellPlaybackCoordinatorTests.swift
@@ -98,6 +98,40 @@ final class BellPlaybackCoordinatorTests: XCTestCase {
     XCTAssertFalse(secondClaim)
   }
 
+  func testFailedFallbackStartIsNotTrackedAsPlayback() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+    XCTAssertTrue(
+      state.claimFallback(
+        planID: planID,
+        progressSeconds: nil,
+        minimumConfirmedProgressSeconds: 0.05,
+        applicationIsActive: true
+      )
+    )
+
+    state.recordFallbackPlaybackStart(planID: planID, didStart: false)
+
+    XCTAssertNil(state.fallbackPlaybackPlanID)
+  }
+
+  func testSuccessfulFallbackStartIsTrackedAsPlayback() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+    XCTAssertTrue(
+      state.claimFallback(
+        planID: planID,
+        progressSeconds: nil,
+        minimumConfirmedProgressSeconds: 0.05,
+        applicationIsActive: true
+      )
+    )
+
+    state.recordFallbackPlaybackStart(planID: planID, didStart: true)
+
+    XCTAssertEqual(state.fallbackPlaybackPlanID, planID)
+  }
+
   func testReplacingPlanInvalidatesStaleWatchdog() {
     var state = CompletionBellWatchdogState()
     let stalePlanID = state.replacePlan()

--- a/LittleMoments/Tests/UnitTests/CoreTests/BellPlaybackCoordinatorTests.swift
+++ b/LittleMoments/Tests/UnitTests/CoreTests/BellPlaybackCoordinatorTests.swift
@@ -20,4 +20,96 @@ final class BellPlaybackCoordinatorTests: XCTestCase {
     XCTAssertEqual(player.items().count, 1)
     XCTAssertTrue(player.currentItem === bellItem)
   }
+
+  func testWatchdogDoesNotFallbackWhenPrimaryBellAdvanced() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+
+    let shouldFallback = state.claimFallback(
+      planID: planID,
+      progressSeconds: 0.1,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: true
+    )
+
+    XCTAssertFalse(shouldFallback)
+  }
+
+  func testWatchdogFallsBackWhenPrimaryBellIsStalled() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+
+    let shouldFallback = state.claimFallback(
+      planID: planID,
+      progressSeconds: 0,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: true
+    )
+
+    XCTAssertTrue(shouldFallback)
+  }
+
+  func testWatchdogFallsBackWhenProgressIsUnknown() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+
+    let shouldFallback = state.claimFallback(
+      planID: planID,
+      progressSeconds: nil,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: true
+    )
+
+    XCTAssertTrue(shouldFallback)
+  }
+
+  func testWatchdogDoesNotFallbackWhileApplicationIsInactive() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+
+    let shouldFallback = state.claimFallback(
+      planID: planID,
+      progressSeconds: nil,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: false
+    )
+
+    XCTAssertFalse(shouldFallback)
+  }
+
+  func testWatchdogFallsBackOnlyOnceForPlan() {
+    var state = CompletionBellWatchdogState()
+    let planID = state.replacePlan()
+
+    let firstClaim = state.claimFallback(
+      planID: planID,
+      progressSeconds: nil,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: true
+    )
+    let secondClaim = state.claimFallback(
+      planID: planID,
+      progressSeconds: nil,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: true
+    )
+
+    XCTAssertTrue(firstClaim)
+    XCTAssertFalse(secondClaim)
+  }
+
+  func testReplacingPlanInvalidatesStaleWatchdog() {
+    var state = CompletionBellWatchdogState()
+    let stalePlanID = state.replacePlan()
+    _ = state.replacePlan()
+
+    let shouldFallback = state.claimFallback(
+      planID: stalePlanID,
+      progressSeconds: nil,
+      minimumConfirmedProgressSeconds: 0.05,
+      applicationIsActive: true
+    )
+
+    XCTAssertFalse(shouldFallback)
+  }
 }

--- a/LittleMoments/Tests/UnitTests/TimerTests/TimerViewModelBellPlaybackTests.swift
+++ b/LittleMoments/Tests/UnitTests/TimerTests/TimerViewModelBellPlaybackTests.swift
@@ -52,6 +52,16 @@ final class TimerViewModelBellPlaybackTests: XCTestCase {
 
     XCTAssertEqual(coordinator.cancelCallCount, 1)
   }
+
+  func testDueScheduledAlertRequestsAudibilityOnce() {
+    timerViewModel.start()
+    timerViewModel.setDurationTarget(seconds: 300)
+
+    timerViewModel.checkScheduledAlert(secondsElapsed: 300)
+    timerViewModel.checkScheduledAlert(secondsElapsed: 301)
+
+    XCTAssertEqual(coordinator.ensureAudibleCalls, [300])
+  }
 }
 
 @MainActor
@@ -59,6 +69,7 @@ private final class SpyBellPlaybackCoordinator: BellPlaybackCoordinating {
   var mode: BellPlaybackMode = .off
   var startCalls: [(startDate: Date, ringBellAtStart: Bool)] = []
   var targetCalls: [(secondsFromSessionStart: Int?, elapsedSeconds: TimeInterval)] = []
+  var ensureAudibleCalls: [TimeInterval] = []
   var finishCallCount = 0
   var cancelCallCount = 0
 
@@ -68,6 +79,10 @@ private final class SpyBellPlaybackCoordinator: BellPlaybackCoordinating {
 
   func setTarget(secondsFromSessionStart: Int?, elapsedSeconds: TimeInterval) {
     targetCalls.append((secondsFromSessionStart, elapsedSeconds))
+  }
+
+  func ensureCompletionBellAudible(elapsedSeconds: TimeInterval) {
+    ensureAudibleCalls.append(elapsedSeconds)
   }
 
   func finishSession() {

--- a/backlog/docs/doc-26 - Feature-Reliable-Completion-Bell-Playback.md
+++ b/backlog/docs/doc-26 - Feature-Reliable-Completion-Bell-Playback.md
@@ -1,5 +1,9 @@
 ---
-
+id: doc-26
+title: 'Feature: Reliable Completion Bell Playback'
+type: feature
+created_date: '2026-08-10 19:18'
+---
 # Feature: Reliable Completion Bell Playback
 
 ## Summary
@@ -72,8 +76,3 @@ This retains one scheduling authority and one primary playback mechanism while u
 
 - `doc-25`: original robust completion bell playback design and spike.
 - `TASK-8`: lower-overhead robust bell playback investigation.
-id: doc-26
-title: 'Feature: Reliable Completion Bell Playback'
-type: feature
-created_date: '2026-08-10 19:18'
----

--- a/backlog/docs/doc-26 - Feature-Reliable-Completion-Bell-Playback.md
+++ b/backlog/docs/doc-26 - Feature-Reliable-Completion-Bell-Playback.md
@@ -1,0 +1,79 @@
+---
+
+# Feature: Reliable Completion Bell Playback
+
+## Summary
+
+Little Moments should strongly prefer an extra completion bell over a meditation ending silently. Robust queue playback remains the primary completion mechanism in every application state. When the timer scene is active, a short watchdog confirms that the queued bell has actually advanced; if it cannot confirm progress, the app also starts the simpler foreground bell player.
+
+The local notification remains an independent system fallback for inactive, backgrounded, or locked-screen sessions.
+
+## Problem
+
+The robust playback path keeps an `AVQueuePlayer` active with looping silence and replaces that silence with the bell at the selected target. In the default hybrid mode, enabling that path also suppresses the ordinary foreground `AVAudioPlayer` bell.
+
+Calling `AVQueuePlayer.play()` proves only that playback was requested. It does not prove that the new bell item became ready, left its waiting state, advanced, or became audible. The current implementation records progress diagnostics one second later but does not recover when the queue transition stalls. Consequently, one ambiguous queue transition can leave a foreground meditation silent even though a simpler playback path is available.
+
+## Product Principle
+
+For an end-of-meditation cue, a duplicate bell is less harmful than no bell. Deduplication should therefore be based on confirmed playback progress, not on an attempted call to `play()`.
+
+This is deliberately a fail-open policy:
+
+- Confirmed primary playback suppresses the foreground fallback.
+- Missing or ambiguous confirmation permits the foreground fallback.
+- Near-simultaneous duplicate playback is acceptable.
+
+## Target Behavior
+
+### Timer scene active
+
+1. The robust coordinator transitions its active queue from silence to the completion bell at the exact target.
+2. A target-scoped watchdog waits for a short grace interval.
+3. If the bell item has made meaningful progress, no fallback is needed.
+4. If progress is absent or cannot be confirmed, the foreground bell player starts.
+5. The one-second UI timer also asks the coordinator to ensure the due bell is audible, protecting against a delayed or missed completion task.
+
+### App inactive, backgrounded, or locked
+
+The robust queue remains the primary audio path. The scheduled local notification remains the independent system fallback. The foreground watchdog does not rely on application timers while the app is inactive.
+
+### Cancellation, target changes, and manual completion
+
+Every planned target has a generation identifier. Clearing or changing a target, cancelling a session, or manually completing it invalidates the old generation so delayed watchdog work cannot play a stale bell.
+
+## Why This Design
+
+### One queue-only mechanism everywhere
+
+This is simple but makes the silence-to-bell queue transition a single point of failure. It is the current effective foreground policy and does not satisfy the reliability preference.
+
+### Mutually exclusive foreground and background mechanisms
+
+Choosing `AVAudioPlayer` while active and `AVQueuePlayer` while inactive avoids duplicates during stable states, but creates a handoff boundary around scene transitions. A session can change state at the deadline, leaving both mechanisms believing the other is responsible.
+
+### Always play both mechanisms in the foreground
+
+This is the smallest fail-open change, but the UI timer can lag the exact target by nearly a second, producing a clearly separated second bell on every successful session.
+
+### Primary playback plus evidence-based watchdog
+
+This retains one scheduling authority and one primary playback mechanism while using the foreground player only when evidence is missing. It narrows duplicates to ambiguous cases without converting an attempted playback call into a false success signal.
+
+## Success Criteria
+
+- A normally advancing robust bell produces one audible foreground completion cue.
+- A stalled or indeterminate robust bell causes a foreground fallback while the timer scene is active.
+- A late watchdog from an old target cannot ring after a target change, cancellation, or reset.
+- Background and locked-screen behavior continues to use robust playback plus the notification fallback.
+- Diagnostics distinguish playback attempted, playback confirmed, fallback requested, and fallback started.
+
+## Related Work
+
+- `doc-25`: original robust completion bell playback design and spike.
+- `TASK-8`: lower-overhead robust bell playback investigation.
+id: doc-26
+title: 'Feature: Reliable Completion Bell Playback'
+type: feature
+created_date: '2026-08-10 19:18'
+---

--- a/backlog/docs/doc-27 - Spec-Completion-Bell-Playback-Watchdog.md
+++ b/backlog/docs/doc-27 - Spec-Completion-Bell-Playback-Watchdog.md
@@ -146,6 +146,20 @@ The change does not add a user setting or alter notification authorization. The 
 - Automated tests cover successful, stalled, inactive, repeated, and stale-generation paths.
 - Existing locked-screen playback tests and quality gates pass.
 - `doc-25` remains historical context; this spec defines the current recovery policy.
+
+## Implementation Result
+
+Implemented on `codex/foreground-bell-watchdog`:
+
+- Robust queue playback remains the primary path in every playback mode that uses audio.
+- The coordinator checks for at least 50 milliseconds of bell-item progress after a 500 millisecond grace period.
+- An active foreground scene receives one `SoundManager` fallback per target generation when progress is missing, non-finite, or unobservable.
+- The UI timer routes its first due event through `ensureCompletionBellAudible`, allowing it to recover an exact-deadline task that has not yet transitioned the queue.
+- Clearing/changing a target and resetting/cancelling a session invalidate stale generations and watchdog tasks.
+- Foreground playback restarts from time zero, and robust teardown avoids deactivating the shared audio session underneath an accepted fallback.
+- Structured diagnostics report progress, fallback starts, and fallback skip reasons.
+
+Validation completed with `bin/fastlane quality_check`: repository-wide formatting and strict lint passed, 122 unit tests passed, 11 UI tests passed, and the `LittleMoments`, `LittleMoments-UI`, and `LittleMomentsWidgetExtension` schemes built successfully.
 id: doc-27
 title: 'Spec: Completion Bell Playback Watchdog'
 type: spec

--- a/backlog/docs/doc-27 - Spec-Completion-Bell-Playback-Watchdog.md
+++ b/backlog/docs/doc-27 - Spec-Completion-Bell-Playback-Watchdog.md
@@ -1,0 +1,153 @@
+---
+
+# Spec: Completion Bell Playback Watchdog
+
+## Objective
+
+Add a target-scoped, foreground-only recovery path to robust completion bell playback. `BellPlaybackCoordinator` remains the sole policy owner and robust queue playback remains primary in all states. The recovery path uses `SoundManager` only when queue progress is unconfirmed after a short grace period.
+
+## Existing Flow
+
+- `TimerViewModel` owns the session start date and selected target.
+- `BellPlaybackCoordinator.setTarget` activates the audio session, starts looping silence, and schedules an exact-deadline task.
+- At the deadline, the coordinator replaces the queue contents with a bell item and calls `play()`.
+- `OneTimeScheduledBellAlert` independently runs from a one-second `Timer`, but suppresses its foreground bell whenever robust audio mode is enabled.
+- A one-second coordinator diagnostic observes playback state but takes no recovery action.
+
+## Proposed API
+
+Extend `BellPlaybackCoordinating` with a due-bell watchdog entry point:
+
+```swift
+func ensureCompletionBellAudible(elapsedSeconds: TimeInterval)
+```
+
+`TimerViewModel` calls this when `OneTimeScheduledBellAlert` first detects that its target is due. The coordinator validates the active target and generation before acting.
+
+Production scene activity should be injected behind a closure or small protocol so unit tests do not depend on `UIApplication` global state. Foreground fallback playback should likewise be injected as a closure, defaulting to `SoundManager.playSound()`.
+
+## Coordinator State
+
+Maintain target-scoped state on `MainActor`:
+
+- Active target seconds.
+- Target generation UUID.
+- Bell item associated with that generation, if primary playback was attempted.
+- Whether primary playback progress has been confirmed.
+- Whether foreground fallback has already been requested for that generation.
+- The completion task and watchdog task.
+
+Changing or clearing a target creates a new generation and cancels both tasks. Session finish/cancel/reset clears all target state.
+
+## Playback Algorithm
+
+### Exact-deadline task
+
+1. Validate the generation and target.
+2. Replace the silent queue contents with the bell item.
+3. Call `play()` and record that primary playback was attempted.
+4. Schedule a watchdog for 500 milliseconds.
+
+### Progress confirmation
+
+At the watchdog deadline, confirm primary playback only when all of the following are true:
+
+- The generation is still current.
+- The coordinator still owns the same queue player and bell item.
+- The bell item's current playback time is finite and greater than a small threshold (for example, 50 milliseconds).
+
+Player status values are retained in diagnostics, but elapsed playback is the success signal. A status of `playing` without advancing media time is not sufficient.
+
+### Foreground fallback
+
+If progress is unconfirmed:
+
+1. Verify that the application has an active scene.
+2. Verify fallback has not already started for this generation.
+3. Mark the fallback as started before invoking the player.
+4. Reset the foreground player's current time and call `play()`.
+
+Failure to inspect primary progress is treated the same as missing progress. This intentionally favors duplicate bells.
+
+### UI timer watchdog
+
+When the one-second scheduled alert becomes due, it calls `ensureCompletionBellAudible` instead of directly playing or suppressing a foreground sound.
+
+- If primary playback is confirmed, it does nothing.
+- If the exact-deadline task has not attempted playback, it initiates the primary transition and watchdog for the current generation.
+- If primary playback was attempted long enough ago and remains unconfirmed, it starts the foreground fallback when active.
+
+This method must be idempotent for a target generation.
+
+## SoundManager Hardening
+
+Before foreground fallback playback:
+
+- Stop any existing playback of the bell.
+- Set `currentTime` to zero.
+- Call `prepareToPlay()` when useful.
+- Call `play()` and return whether the request was accepted.
+
+Returning a Boolean allows the coordinator to record whether fallback playback was accepted without treating it as proof of audibility.
+
+## Diagnostics
+
+Add structured events containing the target generation where practical:
+
+- Primary bell attempted.
+- Primary progress confirmed.
+- Primary progress unconfirmed, including player/item status and waiting reason.
+- Foreground fallback skipped because no scene is active.
+- Foreground fallback started or rejected.
+- Watchdog ignored because its generation is stale.
+
+Diagnostics must not contain personal data.
+
+## Test Plan
+
+### Unit tests
+
+- A queue item that advances beyond the threshold does not invoke fallback.
+- A stalled queue item invokes fallback when the scene is active.
+- Unknown/indeterminate progress invokes fallback when active.
+- An inactive scene does not invoke the foreground fallback.
+- Repeated watchdog calls invoke fallback at most once per generation.
+- Replacing or clearing the target invalidates the previous watchdog.
+- Cancelling/resetting a session invalidates pending fallback work.
+- A due UI timer callback reaches the coordinator rather than directly calling `SoundManager`.
+
+Use injected progress inspection and fallback closures for deterministic tests; unit tests should not wait on real `AVPlayer` timing.
+
+### Integration validation
+
+- Foreground simulator: short timer with normal queue progress produces one bell.
+- Foreground device: force or simulate unconfirmed progress and verify fallback.
+- Locked device: confirm the existing robust bell and notification behavior remains intact.
+- Change and clear a duration near its deadline; confirm no stale bell.
+- Tap Cancel and Complete near the deadline; confirm invalidated watchdog work does not ring later.
+
+## Implementation Sequence
+
+1. Refactor `SoundManager.playSound()` to restart playback deterministically and report request acceptance.
+2. Add coordinator dependencies for scene activity, fallback playback, grace interval, and progress inspection.
+3. Track active target/generation and primary bell attempt state.
+4. Convert the existing progress diagnostic into the recovery watchdog.
+5. Route `OneTimeScheduledBellAlert` through `TimerViewModel` to the coordinator rather than referencing the singleton directly.
+6. Add deterministic coordinator and view-model tests.
+7. Run file-scoped formatting/linting and relevant tests, followed by `bin/fastlane quality_check`.
+
+## Rollout and Risk
+
+The change does not add a user setting or alter notification authorization. The principal behavior risk is an occasional duplicate foreground bell when primary playback begins too slowly to cross the progress threshold. That outcome is accepted by product policy and should be measured through diagnostics. The fallback grace interval can be tuned later without changing the architecture.
+
+## Completion Criteria
+
+- Implementation matches the target-scoped algorithm above.
+- Automated tests cover successful, stalled, inactive, repeated, and stale-generation paths.
+- Existing locked-screen playback tests and quality gates pass.
+- `doc-25` remains historical context; this spec defines the current recovery policy.
+id: doc-27
+title: 'Spec: Completion Bell Playback Watchdog'
+type: spec
+created_date: '2026-08-10 19:18'
+---

--- a/backlog/docs/doc-27 - Spec-Completion-Bell-Playback-Watchdog.md
+++ b/backlog/docs/doc-27 - Spec-Completion-Bell-Playback-Watchdog.md
@@ -1,5 +1,9 @@
 ---
-
+id: doc-27
+title: 'Spec: Completion Bell Playback Watchdog'
+type: spec
+created_date: '2026-08-10 19:18'
+---
 # Spec: Completion Bell Playback Watchdog
 
 ## Objective
@@ -160,8 +164,3 @@ Implemented on `codex/foreground-bell-watchdog`:
 - Structured diagnostics report progress, fallback starts, and fallback skip reasons.
 
 Validation completed with `bin/fastlane quality_check`: repository-wide formatting and strict lint passed, 122 unit tests passed, 11 UI tests passed, and the `LittleMoments`, `LittleMoments-UI`, and `LittleMomentsWidgetExtension` schemes built successfully.
-id: doc-27
-title: 'Spec: Completion Bell Playback Watchdog'
-type: spec
-created_date: '2026-08-10 19:18'
----


### PR DESCRIPTION
## Summary

- Add a target-scoped watchdog for stalled or indeterminate `AVQueuePlayer` completion bells.
- Trigger the foreground bell only when the app is active and primary playback progress is unconfirmed.
- Prevent duplicate or stale fallback playback across target changes, cancellation, and session completion.
- Track fallback attempts separately from successful, currently playing foreground audio before deferring audio-session deactivation.
- Add diagnostics, watchdog state tests, timer integration coverage, and feature documentation.

## Testing

- `bin/fastlane quality_check`: formatting, strict lint, 122 unit tests, 11 UI tests, and all app/widget build schemes passed.
- Review-fix validation: scoped Fastlane formatting and strict lint passed; all 124 `LittleMomentsTests` unit tests passed.
- Backlog CLI successfully indexes `doc-26` and `doc-27`.
- Manual device check: a one-minute foreground timer rang successfully, and diagnostics confirmed primary bell progress without starting the fallback.